### PR TITLE
Add internal tools service page + 7 related blog articles

### DIFF
--- a/src/components/BackToTop.astro
+++ b/src/components/BackToTop.astro
@@ -1,4 +1,4 @@
-<button id="back-to-top" class="relative group w-fit flex pl-8 pr-3 py-1.5 flex-nowrap rounded border border-black/15 dark:border-white/20 hover:bg-black/5 dark:hover:bg-white/5 hover:text-black dark:hover:text-white transition-colors duration-300 ease-in-out">
+<button id="back-to-top" class="relative group w-fit flex pl-8 pr-3 py-1.5 flex-nowrap rounded border border-white/20 hover:opacity-50 transition-opacity duration-300 ease-in-out">
   <svg 
     xmlns="http://www.w3.org/2000/svg" 
     viewBox="0 0 24 24"

--- a/src/components/BlogCard.astro
+++ b/src/components/BlogCard.astro
@@ -1,0 +1,52 @@
+---
+
+type Props = {
+  href: string;
+  title: string;
+  date: Date;
+  author: string;
+  titleColor?: string;
+  label?: string;
+};
+
+const {
+  href,
+  title,
+  date,
+  author,
+  titleColor = "#F4C45C",
+  label = "Read",
+} = Astro.props;
+
+const formatDate = (d: Date) =>
+  new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "2-digit",
+    year: "numeric",
+  }).format(d);
+---
+
+<a
+  href={href}
+  class="group flex min-h-[300px] flex-col justify-between border border-white/5 bg-white/5 p-6 transition-colors duration-300 hover:bg-white/10"
+>
+  <div class="space-y-3">
+  <span class="inline-flex items-center gap-2 text-sm text-[#FAFAFA]/40">
+    {label}
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      class="size-4 stroke-2 fill-none stroke-current rotate-180"
+    >
+      <line x1="5" y1="12" x2="19" y2="12" class="translate-x-2 group-hover:translate-x-0 scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-in-out" />
+      <polyline points="12 5 5 12 12 19" class="translate-x-1 group-hover:translate-x-0 transition-transform duration-300 ease-in-out" />
+    </svg>
+  </span>
+    <h3 class="text-xl font-medium" style={`color: ${titleColor};`}>
+      {title}
+    </h3>
+  </div>
+    <div class="text-sm text-[#FAFAFA]/50">
+      {formatDate(date)} · {author}
+    </div>
+</a>

--- a/src/components/ContactSection.astro
+++ b/src/components/ContactSection.astro
@@ -1,0 +1,45 @@
+---
+---
+
+<section id="contact">
+  <div class="p-6 sm:p-10 border border-white/10">
+    <div class="space-y-6">
+      <h2 class="text-2xl font-medium text-white">
+        Feeling stuck or unsure how to proceed?
+      </h2>
+      <p class="text-base text-body">
+        With every project, we follow a
+        <span class="italic">fixed-time, variable-scope</span>
+        approach inspired by Basecamp's
+        <a
+          href="https://basecamp.com/shapeup"
+          target="_blank"
+          rel="noreferrer"
+          class="text-[#F4C45C] hover:text-[#F4C45C]/80"
+        >
+          Shape Up.
+        </a> Book a short 30 minute call with us to help shape and reduce the scope
+        of your problem until a sensible next step emerges. No obligation beyond
+        that. You'll leave with a clearer framing and a concrete next step, whether
+        or not we continue working together.
+      </p>
+      <div class="flex flex-wrap items-center gap-3 text-base">
+        <a
+          href="https://cal.eu/chris-de-sousa-fxpsnh/30min-shaping-call"
+          target="_blank"
+          rel="noreferrer"
+          class="inline-flex items-center justify-center bg-[#FAFAFA] px-4 py-2 text-[#0A0A0A] transition-colors duration-300 hover:bg-white/80"
+        >
+          Start a conversation
+        </a>
+        or drop us an
+        <a
+          href="mailto:team@codemyriad.io"
+          class="text-body hover:text-[#FAFAFA] hover:underline decoration-[#F4C45C]"
+        >
+          <span class="text-[#F4C45C]">email</span>
+        </a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,17 +6,13 @@ import BackToTop from "@components/BackToTop.astro";
 
 <footer class="">
   <Container>
-    <div class="relative">
-      <div class="absolute right-0 -top-20">
-        <BackToTop />
-      </div>
-    </div>
     <div class="flex justify-between items-center">
       <div>
         &copy; 2024 {`|`}
         {SITE.NAME}
       </div>
       <div class="flex flex-wrap gap-1 items-center">
+        <BackToTop />
         <!-- <button
           id="light-theme-button"
           aria-label="Light theme"

--- a/src/components/VideoPlayer.astro
+++ b/src/components/VideoPlayer.astro
@@ -1,0 +1,90 @@
+---
+type Props = {
+  src: string;
+  type?: string;
+};
+const { src, type = "video/webm" } = Astro.props;
+---
+
+<div class="video-player relative cursor-pointer group">
+  <video class="w-full block" playsinline preload="metadata" loop>
+    <source src={src} type={type} />
+  </video>
+
+  <!-- Overlay button — always visible, icon swaps between play/pause -->
+  <div class="video-overlay absolute inset-0 flex items-center justify-center transition-opacity duration-200">
+    <div class="flex items-center justify-center w-20 h-20 rounded-full border border-white/20 bg-black/40 backdrop-blur-sm transition-all duration-200 group-hover:bg-black/60">
+      <!-- Play icon -->
+      <svg
+        class="video-icon-play w-7 h-7 fill-white ml-1"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <polygon points="5 3 19 12 5 21 5 3" />
+      </svg>
+      <!-- Pause icon (hidden initially) -->
+      <svg
+        class="video-icon-pause w-7 h-7 fill-white hidden"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <rect x="6" y="4" width="4" height="16" />
+        <rect x="14" y="4" width="4" height="16" />
+      </svg>
+    </div>
+  </div>
+</div>
+
+<script>
+  function initVideoPlayers() {
+    document.querySelectorAll<HTMLElement>(".video-player").forEach((wrapper) => {
+      if (wrapper.dataset.initialized) return;
+      wrapper.dataset.initialized = "true";
+
+      const video = wrapper.querySelector("video")!;
+      const overlay = wrapper.querySelector<HTMLElement>(".video-overlay")!;
+      const iconPlay = wrapper.querySelector<HTMLElement>(".video-icon-play")!;
+      const iconPause = wrapper.querySelector<HTMLElement>(".video-icon-pause")!;
+
+      function setPaused() {
+        iconPlay.classList.remove("hidden");
+        iconPause.classList.add("hidden");
+        overlay.style.opacity = "1";
+        overlay.style.pointerEvents = "auto";
+      }
+
+      function setPlaying() {
+        iconPlay.classList.add("hidden");
+        iconPause.classList.remove("hidden");
+        overlay.style.opacity = "0";
+        overlay.style.pointerEvents = "none";
+      }
+
+      // Initial state
+      setPaused();
+
+      wrapper.addEventListener("click", () => {
+        if (video.paused) {
+          video.play();
+        } else {
+          video.pause();
+        }
+      });
+
+      video.addEventListener("play", setPlaying);
+      video.addEventListener("pause", setPaused);
+
+      // Show pause button on hover while playing
+      wrapper.addEventListener("mouseenter", () => {
+        if (!video.paused) overlay.style.opacity = "1";
+      });
+      wrapper.addEventListener("mouseleave", () => {
+        if (!video.paused) overlay.style.opacity = "0";
+      });
+    });
+  }
+
+  document.addEventListener("astro:page-load", initVideoPlayers);
+</script>

--- a/src/content/blog/build-vs-buy-software/index.md
+++ b/src/content/blog/build-vs-buy-software/index.md
@@ -1,0 +1,103 @@
+---
+title: "Build vs. buy: when does building something custom actually make sense?"
+description: "The choice between off-the-shelf software and building something tailored isn't obvious. Here's a practical framework for thinking it through — five questions that make the right answer clear."
+date: "Mar 05 2026"
+author: "Chris De Sousa"
+relatedPosts:
+  - manual-process-cost
+  - saas-subscription-worth-it
+  - what-can-be-automated-small-business
+---
+
+Most business software decisions get framed as a simple question: is there a tool that does this? If the answer is yes, you subscribe to it. If the answer is no, you either do without or figure out a workaround.
+
+This framing misses a third option that's often the right one: building something specifically for your business. Not a massive, expensive engineering project — a focused tool that does the exact job you need, the way your business already works.
+
+This article is a practical guide to the build vs. buy decision. Not an argument for one over the other, but a framework for thinking it through clearly.
+
+---
+
+## Why "just use a SaaS tool" isn't always the answer
+
+Off-the-shelf software is built for the average version of a problem. The vendor has to make something that works well enough for the widest possible range of customers — which means it's designed around assumptions about how businesses work that may or may not match yours.
+
+For common, well-defined problems, this is fine. Accounting software, email, calendar, file storage — these problems are similar enough across businesses that a generic solution handles them well.
+
+But for operational processes that are specific to how your business runs — the particular way you produce client reports, manage a workflow, pull together sales materials, or track project data — the generic solution starts to show its limits. You end up configuring it to approximate what you need, building workarounds for the gaps, and accepting compromises that persist indefinitely.
+
+---
+
+## The questions worth asking
+
+Before committing either way, there are five questions worth sitting with honestly.
+
+**1. How specific is the problem?**
+
+The more specific your use case, the worse off-the-shelf tends to fit. If you're looking for project management software, there are dozens of excellent options. If you need a tool that does something particular to your industry, your client data structure, or your internal process — the field narrows quickly. Generic solutions are designed for generic problems.
+
+**2. How often does this process run?**
+
+A task that happens once a quarter may not be worth building a tool for, even if it's painful when it comes around. A task that happens every week, or for every new client, or every month without fail — that's a different calculation. The frequency multiplies the value of getting it right.
+
+**3. What's the real cost of the current approach?**
+
+This means time, errors, stress, and the opportunity cost of whoever is doing it. A good exercise: calculate the annual hours consumed by the current process and put a rough cost against them. The number is usually larger than people expect. There's [a straightforward framework for doing this calculation properly](/blog/manual-process-cost).
+
+**4. What are you actually paying for SaaS?**
+
+Per-seat pricing compounds as a team grows. If you're paying for ten, fifteen, twenty seats in a tool that handles a specific bounded task — and only a handful of people actually use it meaningfully — it's worth asking whether you're getting value proportional to the cost. There's [a practical way to audit this](/blog/saas-subscription-worth-it) that most businesses find revealing. A custom tool built once, owned outright, starts to look attractive when the subscription maths gets uncomfortable.
+
+**5. What would it take to configure the generic tool to actually work?**
+
+Sometimes the off-the-shelf option is technically capable of doing what you need, but getting it there requires significant setup time, a paid implementation partner, or reshaping your process to match the tool's logic rather than the other way around. The licence cost isn't the real cost in these cases. If the configuration effort is substantial, that changes the equation.
+
+---
+
+## When buying makes more sense
+
+Off-the-shelf wins when:
+
+- The problem is common, well-defined, and well-served by existing options
+- You need something immediately and can live with the trade-offs
+- The use case is likely to evolve significantly and you'd rather let the vendor keep up with it
+- The volume or frequency of the task doesn't justify a build
+- There's a strong ecosystem around the tool (integrations, support, community) that adds genuine value
+
+For many business functions, this describes the situation perfectly. The build vs. buy question doesn't need to be asked about everything — most tools are bought for good reasons.
+
+---
+
+## When building makes more sense
+
+Building wins when:
+
+- The problem is specific enough that no existing tool fits without significant compromise
+- The task runs frequently enough that the time investment compounds into real savings
+- The per-seat cost of an equivalent SaaS tool is becoming significant as the team grows
+- The workaround you're running alongside the current tool is itself consuming meaningful time
+- You've tried the off-the-shelf option and it never quite did the job
+- The process is core enough to your business that owning it outright has strategic value — no vendor dependency, no pricing changes, no risk of the product being discontinued or pivoted
+
+The last point is underweighted in most build vs. buy discussions. When a process is genuinely central to how your business delivers value, depending on a third party to keep that process running — and to keep pricing it reasonably — is a risk that doesn't always get counted.
+
+---
+
+## A common middle ground
+
+In practice, many businesses land somewhere in between: a mix of off-the-shelf tools for the common functions and a small number of custom-built tools for the processes that are specific enough to warrant it.
+
+The custom tools tend to be the ones that would have required the most painful compromises with a generic solution — the [monthly client report](/blog/report-takes-all-day), the sales demo builder, the operational dashboard that pulls from data sources the vendor doesn't integrate with.
+
+These aren't large, complex systems. They're focused tools that do a defined job well. The goal isn't to replace every SaaS tool in the business — it's to identify the small number of processes where the fit is bad enough, and the frequency high enough, that building is clearly the right call. [Understanding which of your processes are actually good automation candidates](/blog/what-can-be-automated-small-business) is a useful first step.
+
+---
+
+## Where to start
+
+If you're at the decision point, the most useful exercise is to list the processes where your current approach — whether that's a SaaS tool you're working around, a spreadsheet, or a manual routine — feels most broken. Not just the ones that are annoying, but the ones where you've made peace with a level of friction that you never should have accepted.
+
+For each one, run through the five questions above. The right answer usually becomes apparent pretty quickly.
+
+---
+
+### If you're at this point with a specific process and want to think through whether building makes sense, we're happy to have that conversation — no commitment required. [See how we work →](/services/internal-tools)

--- a/src/content/blog/key-person-dependency/index.md
+++ b/src/content/blog/key-person-dependency/index.md
@@ -1,0 +1,84 @@
+---
+title: "What happens when the person who understands your workflow leaves?"
+description: "Most small businesses have at least one process that only works because of a specific person. Here's why documentation alone doesn't fix that — and what actually makes a process robust."
+date: "Feb 23 2026"
+author: "Chris De Sousa"
+relatedPosts:
+  - manual-process-cost
+  - report-takes-all-day
+  - what-can-be-automated-small-business
+---
+
+Most small businesses have at least one process that works because of a specific person, not because of a well-designed system. A monthly report that only Sarah knows how to produce. A client onboarding sequence that lives in James's head. A data process that involves steps no one else has ever been asked to explain out loud.
+
+This isn't a sign of bad management. It's how processes develop in fast-moving small teams — someone figures something out, it works, and the business keeps moving. Documentation feels like overhead when everyone's already too busy.
+
+The problem surfaces when that person isn't there.
+
+---
+
+## What it actually looks like
+
+Key-person dependency rarely announces itself as a risk until it becomes a crisis. The most common scenarios:
+
+**Holiday.** Someone takes two weeks off and a monthly process either gets rushed before they leave, gets delayed until they're back, or gets attempted by someone else who discovers mid-way that they don't have all the context they thought they did.
+
+**Illness.** Less predictable than holiday and harder to plan around. The process stalls. Work-arounds get improvised. Things that should have taken an hour take a day, because whoever is covering is figuring it out as they go.
+
+**Departure.** The highest-stakes version. When the person who owns a process leaves — whether planned or not — the knowledge that lived in their head leaves with them. The handover notes, if they exist at all, rarely capture the judgement calls and edge cases that made the process actually work.
+
+**Scaling.** Less dramatic but just as real: the business grows, the process needs to run more often or for more clients, and suddenly the single person who owns it becomes a bottleneck. There's no crisis, just a steady accumulation of pressure and the growing sense that things are more fragile than they should be.
+
+---
+
+## The hidden cost before anyone leaves
+
+The risk doesn't only materialise when someone is gone. It's running all the time.
+
+When a process depends on one person, that person carries it everywhere. They can't take a proper holiday without either rushing through the work before they leave or staying half-available while they're away. Their capacity becomes the process's capacity — if the client base grows, they absorb it; if they're stretched, things slow down; if they're distracted, quality slips. The business can't scale that function without scaling the person, and people aren't infinitely scalable.
+
+There's also the problem of what happens when something goes wrong. If a report goes out with an error and only one person understands the process well enough to diagnose where it came from, you need that person's full attention at exactly the moment the problem is most urgent. That's a difficult position to be in — and one that's entirely avoidable.
+
+---
+
+## Why documentation alone doesn't fix it
+
+The instinctive response to this problem is documentation. Write it all down, create a runbook, make sure there's a record of how things work.
+
+Documentation is better than nothing. But it has a ceiling as a solution, for a few reasons.
+
+First, the parts of a process that are hardest to document are usually the most important ones — the judgement calls, the exceptions, the "you'll know it when you see it" moments that an experienced person navigates automatically. These don't translate cleanly into a written procedure.
+
+Second, documentation goes out of date. The process evolves, shortcuts get added, the underlying tools change slightly, and the documentation quietly stops matching reality. Nobody updates it in real time because nobody has time.
+
+Third, documentation still requires a human to execute the process correctly every time. It reduces the risk of things going wrong, but it doesn't remove the manual effort or the opportunity for error.
+
+---
+
+## What actually makes a process robust
+
+The more durable fix is to move the knowledge out of people's heads and into the system itself — so that the process works correctly because of how it's built, not because of who's running it.
+
+In practice, this means a few things:
+
+**The logic is explicit, not implicit.** Instead of a process that relies on someone knowing to check column D against column G and flag anything over a certain threshold — a tool that does that check automatically and surfaces the result. The judgement call gets encoded once, correctly, and applied consistently every time.
+
+**The steps are enforced, not remembered.** Instead of a checklist that someone has to follow and tick off — a workflow where the steps happen in sequence by design, and where skipping one isn't possible without it being obvious.
+
+**The output is consistent regardless of who runs it.** The right person and a new person get the same result, because the process doesn't require familiarity to execute correctly.
+
+None of this requires complexity. The [kinds of processes that translate well into tools](/blog/what-can-be-automated-small-business) tend to be the ones that already follow consistent rules — they just need someone to build those rules in properly rather than leaving them in someone's head.
+
+---
+
+## A useful test
+
+A simple way to assess any process in your business: could someone who'd never done it before produce the correct output on their first attempt, without asking for help?
+
+If the answer is no — if it would require a briefing, a walkthrough, or access to knowledge that only exists in someone's head — the process has a dependency problem.
+
+The question isn't whether you currently have the right person doing it. It's whether the business would be fine if you didn't.
+
+---
+
+### If you have a process that wouldn't survive the departure of the person who owns it, we're happy to talk through what building a more durable version would involve. [See how we work →](/services/internal-tools)

--- a/src/content/blog/manual-process-cost/index.md
+++ b/src/content/blog/manual-process-cost/index.md
@@ -1,0 +1,78 @@
+---
+title: "How much are manual processes actually costing you?"
+description: "Most business owners know certain tasks take too long — they just haven't done the maths. Here's a simple framework for putting a real number on what your manual processes are costing, so you can decide whether it's worth fixing them."
+date: "Feb 09 2026"
+author: "Chris De Sousa"
+relatedPosts:
+  - report-takes-all-day
+  - key-person-dependency
+  - what-can-be-automated-small-business
+---
+
+Most business owners know, on some level, that certain tasks are taking longer than they should. They just haven't sat down and done the maths. This article is that exercise — a simple way to put a number on what your manual processes are actually costing, so you can make a clearer decision about whether it's worth fixing them.
+
+---
+
+## Start with time, not money
+
+The most honest way to measure the cost of a manual process is to start with how long it takes.
+
+Pick one recurring task — a [monthly client report](/blog/report-takes-all-day), a data check you run every week, an onboarding process you go through with every new client. Now write down:
+
+- **How long does it take?** Be honest. Include the prep, the checking, the fixing when something's off, and the time it takes to recover your train of thought if you're interrupted halfway through.
+- **How often does it happen?** Weekly, monthly, per client?
+- **Who does it?** Is it you? A member of your team whose time has a cost attached to it?
+
+Multiply those numbers together and you have an annual hours figure. It's usually larger than people expect.
+
+A monthly report that takes four hours to produce, every month, is 48 hours a year. That's more than a full working week, spent on one task.
+
+---
+
+## What those hours are actually worth
+
+Time has a cost, but it also has an opportunity cost — and for small, growing businesses, the opportunity cost is usually the bigger number.
+
+If the task is falling on you as a founder or director, the question isn't just "what's my hourly rate?" It's: what else could those hours have been? A week of sales conversations. A week of work that only you can do. A week of thinking clearly about where the business is going rather than processing data.
+
+If it's falling on a team member, the same logic applies. Their time has both a direct cost and a productive alternative. Every hour spent on a manual process is an hour not spent on something that actually moves the business forward.
+
+There's no formula that perfectly captures this. But a useful shortcut is to take your fully-loaded cost per hour (salary plus overheads, divided by working hours in the year) and multiply it by the hours consumed. Then ask yourself: if you could have those hours back, what's the most valuable thing you'd do with them? That number — however rough — is your opportunity cost.
+
+---
+
+## The costs that don't show up in hours
+
+Time is the obvious cost. There are two others worth accounting for.
+
+**Error risk.** Manual processes are done by humans, which means they go wrong. Not often — but the consequence when they do can be disproportionate. A report goes out with the wrong numbers. A client sees something they shouldn't. A calculation is off and you only notice three months later. Each of those events carries a cost: in time spent fixing it, in the client relationship, and in the low-grade anxiety of knowing it could happen again.
+
+The fragility of a manual process isn't just the mistakes themselves — it's the concentration required to avoid them. Checking your own work. Cross-referencing. Willing yourself to focus for long enough to be certain. That sustained effort has a real cost, even when nothing goes wrong.
+
+**Person dependency.** If the process only works because one person understands it — and that person goes on holiday, or leaves — what happens? The knowledge that lives in someone's head isn't an asset. It's a liability. This is worth thinking through carefully: [what happens when the person who owns that process isn't there](/blog/key-person-dependency) is a question most businesses leave unanswered until it becomes a crisis.
+
+---
+
+## A worked example
+
+Here's how this looks in practice.
+
+Say you run a small property management business and produce monthly client reports. Each report takes about three hours: pulling the data, reformatting it, checking it, and making it look presentable. You have twelve clients. That's 36 hours a month, or 432 hours a year — more than ten working weeks spent entirely on report production.
+
+Your operations manager handles most of it. At a fully-loaded cost of £35 per hour, that's over £15,000 a year in direct labour cost, just for this one task. It doesn't include the two or three times a year something goes wrong and has to be corrected. It doesn't include the months when a client grows and adds more properties, and the workload grows with them.
+
+Against that figure, a tool that automates the process looks very different than it did before the maths. If you're unsure whether your process is a good candidate, [there's a straightforward way to assess that](/blog/what-can-be-automated-small-business).
+
+---
+
+## What to do with this number
+
+The point of this exercise isn't to produce a precise figure — it's to shift the question from "is fixing this worth the effort?" to "can I afford not to?"
+
+Once you have a rough annual cost in front of you, the decision gets much clearer. Either the cost of fixing it is less than what you're currently spending (in which case it's a straightforward investment), or it isn't (in which case you've saved yourself the time of pursuing it).
+
+Most of the time, when people do this exercise honestly, the number surprises them. The task that felt like a minor irritation turns out to be consuming a significant slice of the year. And once you can see it, it's hard to unsee.
+
+---
+
+### If you've done this exercise and want to talk through what fixing a specific process might involve, we're happy to have that conversation — no pitch until we understand the problem. [See how we work →](/services/internal-tools)

--- a/src/content/blog/report-takes-all-day/index.md
+++ b/src/content/blog/report-takes-all-day/index.md
@@ -1,0 +1,93 @@
+---
+title: "You already have the data. Why does the report still take all day?"
+description: "The data is there — it's the assembly that takes hours. Here's where the time actually goes in manual reporting, and what automating that process typically involves."
+date: "Feb 16 2026"
+author: "Chris De Sousa"
+relatedPosts:
+  - manual-process-cost
+  - key-person-dependency
+  - what-can-be-automated-small-business
+---
+
+There's a particular frustration that comes with producing client reports manually. The underlying information exists — it's been collected, it's sitting in your systems, it's accurate enough. The problem is that getting it from there to a finished document, formatted and ready to share, still takes hours. Every time.
+
+This article is about why that gap exists, where the time actually goes, and what closing it typically involves.
+
+---
+
+## The assembly problem
+
+The data and the report are not the same thing. That sounds obvious, but it's worth making explicit, because it explains why having good data doesn't automatically mean reports are easy.
+
+Between raw operational data and a finished client document, there are usually several steps: extracting or exporting the data from wherever it lives, getting it into the format the report needs, doing whatever calculations or summaries are required, populating a template, checking the output, and then distributing it. None of these steps are particularly hard. Together, they take a significant amount of time — and they have to be repeated in full, every reporting cycle, for every client.
+
+The assembly process is the gap. The data is fine. The report isn't difficult to produce. The problem is the number of manual steps required to get from one to the other, repeated on a schedule, by a person. It's worth [putting a number on what that assembly time is actually costing](/blog/manual-process-cost) — the annual figure tends to be larger than people expect.
+
+---
+
+## Where the hours actually go
+
+If you've ever timed yourself producing a client report, the breakdown tends to look something like this.
+
+**Pulling the data.** This often involves logging into one or more systems, running an export, and getting the output into a working file. Depending on how the data is structured and how many sources are involved, this can take anywhere from ten minutes to an hour.
+
+**Formatting and restructuring.** Raw exports rarely come out in the shape the report needs. Columns are in the wrong order. Data is at a different level of granularity than the summary requires. Numbers need to be reformatted or recalculated. This is the step that tends to take longer than expected, especially if the data isn't always clean.
+
+**Populating the template.** Once the data is in the right shape, it has to go into the report itself. If the report is a document rather than a spreadsheet, this often means copying values in manually. If there are charts or tables, those need to be updated. If there are narrative sections, those need to be written or updated to reflect this period's numbers.
+
+**Checking.** Before anything goes to a client, someone has to check it. This is the step that takes longer when you're tired or when the data required more manipulation than usual, because checking your own work requires concentration. It's also the step that gets skipped when time is short — which is how mistakes get out.
+
+**Distributing.** Exporting the final document, attaching it to an email, writing the covering message, sending. This is usually quick, but it's still a step.
+
+Add those up across a client base of ten or fifteen, and the monthly reporting run becomes a multi-day exercise.
+
+---
+
+## Why this doesn't get fixed sooner
+
+The most common reason manual reporting persists longer than it should is that it works. The reports go out. Clients receive them. The process, while slow and effortful, produces an acceptable output.
+
+There's also a sense in which reporting is seen as a fixed cost of the business rather than a variable one. It's always taken this long, so it's expected to take this long. The question of whether it has to take this long doesn't always get asked, because the process has become part of the furniture.
+
+A third reason: the people who know how the reporting works are the same people who are too busy doing it to redesign it. The time required to think about fixing the process gets absorbed by the time required to run it. There's also a quiet risk here — [when the reporting process is understood by only one or two people](/blog/key-person-dependency), the business becomes more fragile than it looks.
+
+---
+
+## What automated reporting actually involves
+
+Automated reporting doesn't mean removing humans from the picture entirely. It means removing the assembly steps — the manual work of getting data into a format, populating a template, and producing a finished document — so that the human judgment that genuinely can't be automated (reviewing the output, noticing something unusual, deciding what to communicate to the client) can happen without the overhead.
+
+In practice, the approach depends on where the data lives and what the report needs to look like. But the general shape is: a tool takes a structured data input, applies a defined set of rules to it, and produces a finished output. That output might be a PDF, a web page, or a formatted document — depending on what the report needs to be.
+
+The important thing is that the process doesn't change how the data is collected. That's usually the part that works already. It changes what happens to the data afterward.
+
+---
+
+## The result, in concrete terms
+
+The best way to illustrate this is with specifics.
+
+A business managing twelve client accounts, each requiring a monthly report, was spending around three hours per client per month on report production — 36 hours in total. After building an automated reporting workflow, that time dropped to under an hour for the entire batch: a quick review to confirm the outputs looked correct, then distribution. The reports themselves became more consistent and better-formatted than the manual versions, because the template was applied identically every time.
+
+The hours that were being consumed by assembly went back to the business. The risk of a mistake going out to a client decreased significantly, because the process no longer depended on a person checking their own manual work while tired at the end of the month.
+
+---
+
+## Is this the right fix for every business?
+
+Not necessarily. Automated reporting makes most sense when:
+
+- The reports follow a consistent structure that repeats each period
+- The underlying data already exists in a structured form somewhere
+- The volume of reports — or the effort per report — is large enough that the time cost is meaningful
+- The process is running on a schedule (monthly, quarterly) rather than being entirely ad hoc
+
+It's a poor fit when every report is genuinely bespoke, or when the data is so inconsistent or variable that defining a reliable process would be harder than the manual work it replaces.
+
+If you're unsure whether your reporting setup fits this pattern, the [self-assessment in this article](/blog/what-can-be-automated-small-business) gives a straightforward set of questions to work through.
+
+But for most businesses producing regular, structured reports from operational data they're already collecting, the assembly problem is solvable. The data is already there. The report doesn't have to take all day.
+
+---
+
+### If you want to talk through whether automated reporting makes sense for how your business works, we're happy to have that conversation — no pitch until we understand the problem. [See how we work →](/services/internal-tools)

--- a/src/content/blog/saas-subscription-worth-it/index.md
+++ b/src/content/blog/saas-subscription-worth-it/index.md
@@ -1,0 +1,91 @@
+---
+title: "At what point does a software subscription stop being worth it?"
+description: "Per-seat SaaS pricing compounds quietly as teams grow. Here's a practical framework for auditing your subscriptions and identifying when building something you own is the smarter long-term decision."
+date: "Mar 02 2026"
+author: "Chris De Sousa"
+relatedPosts:
+  - manual-process-cost
+  - build-vs-buy-software
+  - what-can-be-automated-small-business
+---
+
+Software subscriptions have a way of accumulating quietly. One tool for project management, one for client communication, one for reporting, one that someone signed up for eighteen months ago and nobody's entirely sure why. Each one, on its own, felt like a reasonable decision at the time. Together, they add up to a number that tends to surprise people when they actually look at it.
+
+This isn't an argument against software subscriptions. Most of them are genuinely useful, and the right tool at the right price is one of the better investments a growing business can make. But there's a point at which the economics shift — where what you're paying no longer reflects what you're getting — and it's worth understanding where that line is.
+
+---
+
+## The per-seat problem
+
+Most business software is priced per user, per month. In the early days of a team, this feels fine. Five seats at £20 each is £100 a month — manageable, forgettable.
+
+The problem is that this number scales with your headcount, not your usage. As you hire, the cost goes up whether or not the new people actually need the tool, or use it in any meaningful way. By the time you have fifteen or twenty people, you're paying for fifteen or twenty seats in every tool, even though the reality is usually that a handful of people use each one regularly and the rest log in occasionally.
+
+The honest question to ask about any per-seat tool is: if you stripped out the people who barely use it and only paid for active users, what would the real cost be? And is the value being generated — by the people who do use it — worth that?
+
+---
+
+## The workaround problem
+
+A more telling sign that a tool isn't working for you: you're running a workaround alongside it.
+
+This looks like maintaining a spreadsheet to capture the things the tool can't handle. Or exporting data out of it every month to do something the tool should theoretically do but doesn't quite manage. Or building a process that lives partially inside the software and partially outside it, because the software doesn't cover the whole job.
+
+When this happens, you're effectively paying twice. Once for the subscription, and once in the time your team spends on the workaround. The software isn't saving you work — it's changed what the work looks like, without reducing how much of it there is.
+
+This is the version of the problem that tends to build quietly. The workaround becomes normal. The team adapts to it. Nobody questions it because it works, technically. But [the cost is real, and worth quantifying](/blog/manual-process-cost).
+
+---
+
+## The configuration problem
+
+Some tools are cheap and flexible enough to be shaped into what you need. Others come with a specific way of doing things, and adapting to them means changing how your business works rather than the other way around.
+
+The configuration problem is when a tool almost fits, but getting it to fully fit would require either significant setup time, a paid implementation, or reshaping your process to match the tool's logic. In these cases, the upfront licence cost isn't the real cost. The real cost is what it takes to make the thing actually work for you — and often, whether anyone has done that fully or whether it's been set up well enough to get by.
+
+The question worth asking is: are we using this tool, or are we working around it?
+
+---
+
+## A simple audit
+
+If you want to do a quick health check on your current software costs, here's a straightforward approach.
+
+List every subscription you're paying for. For each one, write down:
+
+1. The monthly cost (total, not per seat)
+2. How many people use it regularly — not occasionally, regularly
+3. What it would cost in time or money to operate without it
+
+The third question is the important one. If the answer is "it would take an hour a week of manual work to replace", that's useful information. If the answer is "we genuinely couldn't function without it", that's useful information too. The tools worth paying for are the ones where the alternative is significantly worse. The ones worth questioning are the ones where the alternative is a bit of spreadsheet work that a small team could manage.
+
+This exercise often surfaces one or two tools that nobody would miss if they disappeared, and one or two that are clearly earning their cost. The ones in the middle are the ones worth thinking about.
+
+---
+
+## When building something makes more sense
+
+There's a category of problem where neither paying for a subscription nor doing things manually is the right answer — where the better option is building something you own outright. The [build vs. buy decision](/blog/build-vs-buy-software) is worth thinking through properly rather than defaulting to whichever option is most familiar.
+
+This tends to be the case when:
+
+- The tool you need doesn't exist, or the closest thing on the market requires so many compromises that it never quite works
+- Your use case is specific enough that you'd spend more time configuring a generic tool than it would take to build something tailored
+- The per-seat cost is becoming significant as your team grows, and the tool is doing a defined, bounded job that a custom solution could do instead
+- You've been on a trial for something and decided not to pull the trigger — because the fit wasn't right, the price wasn't right, or both
+
+The upside of building is that you own what you've built. There's no renewal conversation. No per-seat pricing that follows your headcount. No dependency on a vendor keeping a feature or a pricing model you've structured your operations around.
+
+The obvious limitation is that building takes time and expertise — and not every problem is worth the investment of either. The right call depends on how central the task is, how often it runs, and [what it costs you currently to do it the way you're doing it](/blog/manual-process-cost).
+
+---
+
+## The honest answer
+
+There's no universal threshold. A £200-a-month subscription is excellent value if the alternative would cost you three hours of a director's time every week. It's poor value if it's handling one task that a simpler, cheaper, owned solution could do just as well.
+
+The discipline is doing the comparison honestly rather than letting subscriptions accumulate by default. Most businesses, when they do that audit, find at least one tool they'd cancel and one situation they hadn't considered building a solution for.
+
+---
+
+### If you're at the point of questioning a specific tool and want to think through whether building an alternative makes sense, we're happy to help with that conversation — no commitment required. [See how we work →](/services/internal-tools)

--- a/src/content/blog/vibe-coding-ceiling/index.md
+++ b/src/content/blog/vibe-coding-ceiling/index.md
@@ -1,0 +1,82 @@
+---
+title: "The vibe coding ceiling: what to do when you've built 80% of something and can't finish it"
+description: "AI coding tools let non-technical founders get surprisingly far. Here's what's in that last 20% that stops a prototype becoming a production tool — and what your options are for getting past it."
+date: "Mar 09 2026"
+author: "Chris De Sousa"
+relatedPosts:
+  - build-vs-buy-software
+  - what-can-be-automated-small-business
+  - manual-process-cost
+---
+
+Something interesting has happened in the last couple of years. A growing number of non-technical founders and directors have started building things — real, functional tools — using AI coding assistants. They get further than they expected. The prototype actually works. The demo is convincing. And then, somewhere around the 80% mark, it stops moving forward.
+
+This article is about that ceiling: what causes it, why it's not a personal failure, and what the options are for getting past it.
+
+---
+
+## Why the first 80% feels deceptively achievable
+
+AI coding tools are genuinely good at the part of software development that most people imagine is the hard part: turning a clear description of what you want into working code. Describe a form, get a form. Describe a data transformation, get a script that does it. The gap between an idea and something that visibly works has collapsed.
+
+This creates a reasonable impression that building software is now within reach for anyone with enough patience and a clear enough idea of what they want. And for a prototype, a proof of concept, or a demo — that impression is largely correct.
+
+The problem is that what makes a prototype work and what makes a production tool work are different things. And the gap between them — the last 20% — is where most of the genuinely difficult engineering lives.
+
+---
+
+## What's actually in that last 20%
+
+The features that make a tool useful in a demo are not the same as the features that make a tool reliable in daily use. Here's what tends to be missing:
+
+**Error handling.** A prototype works when the input is clean and expected. Real use involves messy data, unexpected file formats, users doing things the tool wasn't designed for, and network requests that fail. A tool that hasn't been built to handle these gracefully breaks — sometimes visibly, sometimes silently, which is worse.
+
+**Edge cases.** Every process has exceptions. The client whose data is structured differently. The month where the numbers come in late. The file that's slightly wrong. A prototype built around the typical case stops working the moment the atypical case shows up.
+
+**Data integrity.** When a tool is doing something consequential — producing client reports, processing financial data, updating records — it needs to be correct every time, not most of the time. Building the checks and safeguards that guarantee this is unglamorous, important work that AI tools don't naturally prioritise.
+
+**Deployment and hosting.** A script that runs on a laptop is not the same as an application that runs reliably for a whole team, from any machine, without someone having to set it up manually. Getting from one to the other involves infrastructure decisions that are invisible in the prototype stage.
+
+**Maintenance.** The underlying APIs and services a tool depends on change. The data structure it processes evolves. The business's needs shift. A tool that can't be updated without breaking is a tool on borrowed time.
+
+None of this is exotic. It's just the part of software development that requires experience and engineering judgement rather than the ability to describe what you want clearly.
+
+---
+
+## Why it's not a failure
+
+It's worth saying this directly: getting 80% of the way with an AI coding tool is not a failure. It's a genuinely impressive outcome, and it means you've done something useful — you've validated that the tool you want is buildable, you've defined the requirements clearly enough to get a working prototype, and you've identified a real problem worth solving.
+
+The ceiling isn't a sign that you've done something wrong. It's a sign that you've hit the natural boundary of what the tools are designed to do well.
+
+AI coding assistants are optimised for generating code quickly from clear descriptions. They're not optimised for the iterative, judgement-heavy work of making that code robust, handling failure gracefully, and building something that will keep working six months from now without someone maintaining it carefully.
+
+That's not a criticism of the tools — it's just an honest description of what they're for.
+
+---
+
+## What the options look like from here
+
+When you've hit this ceiling, there are broadly three ways forward.
+
+**Keep pushing with AI tools.** Sometimes the remaining problems are small enough that persistent prompting gets there. If the main issue is a specific bug or a single missing feature, this may be the right call. The risk is spending another week on something that would take an experienced developer an afternoon — or making the codebase more complicated in ways that make the real fix harder later.
+
+**Hand it off to a developer with context.** The prototype you've built isn't wasted. It's a detailed specification of what you want, expressed in working code. A developer who can read it and understand the intent can often finish the job faster than building from scratch — because the hard thinking about what the tool should do has already been done. The goal is finishing and hardening something that's already 80% there, not starting over. It's worth thinking through the [build vs. buy question properly](/blog/build-vs-buy-software) at this stage, since handing off a prototype sits in interesting territory between the two.
+
+**Rebuild properly from the beginning.** Sometimes the prototype has accumulated enough structural problems — the wrong architecture choices, the brittle dependencies — that the cleanest path forward is a proper rebuild with the prototype as a specification. This sounds discouraging, but it's often faster than it sounds: the requirements are crystal clear, the scope is defined, and there are no unknowns about whether the approach is viable.
+
+Which option is right depends on how close "80% done" actually is, what the remaining problems are, and how the tool will be used in practice.
+
+---
+
+## A question worth asking
+
+If you have a half-finished tool sitting on your machine that you built yourself and can't quite get over the line — the most useful thing to ask is: what exactly is broken or missing?
+
+Sometimes the answer is a specific list of things. Sometimes it's more of a vague sense that it's not quite reliable enough to trust with real work. Either way, that answer shapes what happens next.
+
+The prototype you've built demonstrates that you know what you want. That's the hardest part of any software project. The engineering to finish it is the tractable part. And if you're not sure whether the thing you've built is actually [a good candidate for a proper automated tool](/blog/what-can-be-automated-small-business), it's worth checking before investing more time in it.
+
+---
+
+### If you've hit this ceiling with something you've been building and want a second opinion on what it would take to finish it properly, we're happy to have a look — no commitment required. [See how we work →](/services/internal-tools)

--- a/src/content/blog/what-can-be-automated-small-business/index.md
+++ b/src/content/blog/what-can-be-automated-small-business/index.md
@@ -1,0 +1,93 @@
+---
+title: "What can actually be automated in a 10–25 person business (and what can't)"
+description: "A practical breakdown of which tasks in a small growing business are genuinely good automation candidates — and a five-question self-assessment to find your best opportunities."
+date: "Feb 02 2026"
+author: "Chris De Sousa"
+relatedPosts:
+  - manual-process-cost
+  - report-takes-all-day
+  - key-person-dependency
+---
+
+"Automation" is one of those words that sounds straightforward until you try to act on it. Automate what, exactly? The whole process? Part of it? What does that even involve?
+
+This article is a practical breakdown — the kinds of tasks in a small growing business that are genuinely good candidates for automation, the kinds that aren't, and a simple self-assessment to help you work out where your best opportunities are.
+
+No jargon, no overselling. Just an honest map of where automation tends to pay off.
+
+---
+
+## What automation actually means here
+
+For the purposes of this article, automation means replacing a human-executed, manual step in a recurring process with a step that runs itself — triggered by a condition, a schedule, or an input, without someone having to do it.
+
+It doesn't mean artificial intelligence making judgement calls on your behalf. It doesn't mean replacing your team. It means the routine, repeatable, rule-based work that currently requires a person's time stops requiring a person's time.
+
+---
+
+## Tasks that automate well
+
+These are the kinds of tasks where the effort-to-payoff ratio is most favourable.
+
+**Data transformation and reformatting.** Moving data from one format or structure to another — from a raw export to a clean report, from a spreadsheet to a formatted document, from one system's output to another system's input. The logic is consistent, the steps are defined, and the task happens repeatedly. These are usually the best candidates.
+
+**Report generation.** Producing structured, recurring reports from existing data. Monthly client reports, weekly operational summaries, invoicing data — anything where the format is consistent and the underlying data already exists somewhere. The manual work is almost entirely in the assembly. [Why that assembly takes as long as it does](/blog/report-takes-all-day) is worth understanding before trying to fix it. Automate the assembly and the human work becomes reviewing and sending.
+
+**File processing and intake.** Handling incoming files — reading them, extracting the relevant data, routing them appropriately. If your business regularly receives files in a consistent format (sales data, bookings, client submissions) and someone has to manually process them each time, this is automatable.
+
+**Notifications and alerts.** Anything where a person is currently checking something to see if it has reached a threshold — a number going above or below a target, a deadline approaching, a status changing. These checks can be built into a system that flags the relevant moment rather than requiring someone to look for it.
+
+**Populating templates.** Generating standard documents from variable data — contracts, proposals, reports, onboarding packs. If there's a consistent template and the variable content comes from data you already have, the population step is automatable.
+
+**Connecting tools that don't talk to each other.** Many small businesses run on a collection of software tools that each work well but don't integrate. Data has to be manually moved between them. These connection points are often automatable — a workflow that watches for new data in one system and moves it to another, without someone doing it manually.
+
+---
+
+## Tasks that don't automate well
+
+These are the kinds of tasks where the manual involvement is harder to remove, or where the automation doesn't pay for itself.
+
+**Tasks that require genuine judgement.** Anything where the right answer depends on context, relationship knowledge, or experience that isn't captured in the data. Deciding how to handle an unusual client situation. Choosing the right tone for a difficult communication. Interpreting ambiguous feedback. Automation can support these tasks — surfacing relevant information, reducing admin — but it can't replace the thinking.
+
+**Highly variable, unpredictable tasks.** Automation works well when the process is consistent enough to define clearly. If every instance of a task is genuinely different — different inputs, different required outputs, different rules — the cost of building a robust automation may exceed the benefit.
+
+**Tasks that happen rarely.** A quarterly process that takes three hours is probably not worth automating. The calculus changes when the task is weekly, monthly, or scales with client or team numbers.
+
+**Tasks in flux.** If a process is actively changing — if the business hasn't settled on how it wants to do something — automating it too early is risky. Build once the process is stable.
+
+**Creative and relationship work.** Writing, designing, client communication, strategy. These aren't automation candidates. The value in them is the human judgement and perspective they involve.
+
+---
+
+## A self-assessment
+
+For any recurring task in your business, these five questions will tell you whether it's worth pursuing:
+
+**1. Does it happen on a regular schedule or trigger?**
+Weekly, monthly, per client, per project — anything that recurs predictably is a candidate. Ad hoc tasks are harder.
+
+**2. Does it follow consistent rules?**
+If someone else could do it correctly by following a clear set of steps, the logic can probably be automated. If it requires reading the room, it's less clear.
+
+**3. How much time does it consume annually?**
+Multiply the time per instance by how often it happens. Anything over 20–30 hours per year is worth a look. If you want to [turn that into a proper cost figure](/blog/manual-process-cost), there's a straightforward framework for doing so.
+
+**4. Does it depend on data that already exists somewhere?**
+The best automation candidates are processes where the underlying information already lives in a system — it's just not in the right format or place. If new data has to be created or gathered each time, the task is harder to automate.
+
+**5. What's the cost of an error?**
+Some tasks can tolerate the occasional mistake — an internal process, a draft that gets reviewed. Others can't — anything that goes directly to a client, or that feeds financial records. The higher the error cost, the more valuable an automated process becomes, because it removes the variability of human execution. It's also worth asking [whether the process currently depends on one person to run correctly](/blog/key-person-dependency) — because that's a fragility problem that automation solves at the same time.
+
+---
+
+## What the realistic outcome looks like
+
+For most 10–25 person businesses, there are usually two or three processes that score well against these questions — that are recurring, rule-based, time-consuming, and data-driven enough that automation makes clear sense.
+
+These aren't sweeping transformations. They're specific tools that do a defined job: take this data, apply these rules, produce this output. The payoff is measured in hours returned to the team, errors removed from a process, and ceilings lifted from growth.
+
+The goal isn't to automate everything. It's to identify the small number of things where the manual work is genuinely unnecessary, and fix those. If you've already tried to build something yourself and hit a wall, [that's a different but related situation](/blog/vibe-coding-ceiling) with its own set of options.
+
+---
+
+### If you've worked through this and think you have a process worth looking at, we're happy to talk through whether automation is the right fix — and what that would involve. [See how we work →](/services/internal-tools)

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -8,6 +8,7 @@ const blog = defineCollection({
     date: z.coerce.date(),
     author: z.string(),
     draft: z.boolean().optional(),
+    relatedPosts: z.array(z.string()).optional(),
   }),
 });
 

--- a/src/content/services/01-local-first-architecture.md
+++ b/src/content/services/01-local-first-architecture.md
@@ -1,5 +1,4 @@
 ---
 title: Local-first architecture
 description: Low-latency interfaces that keep teams working across disconnected devices. Designed for operational environments where accuracy and uptime matter.
-href: /#local-first-architecture
 ---

--- a/src/content/services/02-fixing-brittle-internal-systems.md
+++ b/src/content/services/02-fixing-brittle-internal-systems.md
@@ -1,5 +1,5 @@
 ---
 title: Fixing brittle internal systems
 description: Custom internal tools that replace spreadsheets, workarounds, and brittle automation. Built around how work actually gets done.
-href: /#fixing-brittle-internal-systems
+href: /services/internal-tools
 ---

--- a/src/content/services/03-short-feedback-loops.md
+++ b/src/content/services/03-short-feedback-loops.md
@@ -1,5 +1,4 @@
 ---
 title: Short feedback loops
 description: We use rapid prototyping and design-to-code workflows to explore ideas in working form early. This allows teams to make better decisions with less back-and-forth.
-href: /#short-feedback-loops
 ---

--- a/src/content/services/04-making-systems-dependable.md
+++ b/src/content/services/04-making-systems-dependable.md
@@ -1,5 +1,4 @@
 ---
 title: Right-sized infrastructure
 description: CI/CD and infrastructure designed for the actual scale of the problem. Reliable without unnecessary complexity or cost.
-href: /#right-sized-infrastructure
 ---

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -5,6 +5,8 @@ import Container from "@components/Container.astro";
 import FormattedDate from "@components/FormattedDate.astro";
 import { readingTime } from "@lib/utils";
 import BackToPrev from "@components/BackToPrev.astro";
+import BlogCard from "@components/BlogCard.astro";
+import ContactSection from "@components/ContactSection.astro";
 
 export async function getStaticPaths() {
   const posts = (await getCollection("blog"))
@@ -19,6 +21,12 @@ type Props = CollectionEntry<"blog">;
 
 const post = Astro.props;
 const { Content } = await post.render();
+
+const allPosts = await getCollection("blog");
+const blogMap = Object.fromEntries(allPosts.map((p) => [p.slug, p]));
+const relatedPosts = (post.data.relatedPosts ?? [])
+  .map((slug) => blogMap[slug])
+  .filter(Boolean);
 ---
 
 <PageLayout title={post.data.title} description={post.data.description}>
@@ -26,26 +34,76 @@ const { Content } = await post.render();
     <div class="animate">
       <BackToPrev href="/blog">To Blog</BackToPrev>
     </div>
-    <div class="space-y-1 my-10">
+    <div class="space-y-3 my-10">
       <div class="animate flex items-center gap-1.5">
-        <div class="font-base text-sm">
+        <div class="font-base text-sm text-[#7ec7ff]">
           <FormattedDate date={post.data.date} />
         </div>
         &bull;
-        <div class="font-base text-sm">
+        <div class="font-base text-sm text-[#7ec7ff]">
           {readingTime(post.body)}
         </div>
         &bull;
-        <div class="font-base text-sm">
+        <div class="font-base text-sm text-[#7ec7ff]">
           {post.data.author}
         </div>
       </div>
-      <div class="animate text-2xl font-semibold text-black dark:text-white">
+      <div class="animate text-4xl leading-[120%] font-semibold text-white">
         {post.data.title}
       </div>
     </div>
     <article class="animate">
       <Content />
     </article>
+    {relatedPosts.length > 0 && (
+      <div class="mt-16 space-y-6">
+        <div class="border-t border-white/10 pt-4">
+          <h2 data-typeout class="text-base font-medium text-[#FAFAFA]/40">/ Related reading</h2>
+        </div>
+        <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {relatedPosts.map((related) => (
+            <BlogCard
+              href={`/blog/${related.slug}`}
+              title={related.data.title}
+              date={related.data.date}
+              author={related.data.author}
+              titleColor="#FAFAFA"
+            />
+          ))}
+        </div>
+      </div>
+    )}
+    <div class="mt-16">
+      <ContactSection />
+    </div>
   </Container>
 </PageLayout>
+
+<script>
+  function initTypeout() {
+    document.querySelectorAll<HTMLElement>("[data-typeout]").forEach((el) => {
+      const text = el.textContent?.trim() ?? "";
+      el.textContent = "";
+
+      const obs = new IntersectionObserver(
+        (entries) => {
+          if (entries[0].isIntersecting) {
+            obs.disconnect();
+            let i = 0;
+            (function type() {
+              if (i < text.length) {
+                el.textContent += text[i++];
+                setTimeout(type, 45);
+              }
+            })();
+          }
+        },
+        { threshold: 0.5 }
+      );
+
+      obs.observe(el);
+    });
+  }
+
+  document.addEventListener("astro:page-load", initTypeout);
+</script>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,83 +1,63 @@
 ---
-import { type CollectionEntry, getCollection } from "astro:content";
+import { getCollection } from "astro:content";
 import PageLayout from "@layouts/PageLayout.astro";
 import Container from "@components/Container.astro";
+import BlogCard from "@components/BlogCard.astro";
 import { BLOG } from "@consts";
-import { ArrowRight } from "@lucide/astro";
 
-const data = (await getCollection("blog"))
+const posts = (await getCollection("blog"))
   .filter((post) => !post.data.draft)
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 
-type Acc = {
-  [year: string]: CollectionEntry<"blog">[];
-};
 
-const posts = data.reduce((acc: Acc, post) => {
-  const year = post.data.date.getFullYear().toString();
-  if (!acc[year]) {
-    acc[year] = [];
-  }
-  acc[year].push(post);
-  return acc;
-}, {});
-
-const years = Object.keys(posts).sort((a, b) => parseInt(b) - parseInt(a));
-
-const blogTitleColors = ["#F4C45C", "#F4915C"];
-
-const formatDate = (date: Date) =>
-  new Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "2-digit",
-    year: "numeric",
-  }).format(date);
 ---
 
 <PageLayout title={BLOG.TITLE} description={BLOG.DESCRIPTION}>
   <Container>
     <div class="space-y-10">
-      <h1 class="text-lg text-[#FAFAFA]">Blog</h1>
-      <div class="flex flex-col gap-4">
+      <h1 data-typeout class="text-6xl font-bold text-white">Blog</h1>
+      <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {
-          years.map((year) => (
-            <section class="space-y-4">
-              <h2 class="text-base text-[#FAFAFA]/50">{year}</h2>
-              <ul class="flex flex-col gap-4">
-                {posts[year].map((post, index) => (
-                  <li>
-                    <a
-                      href={`/blog/${post.slug}`}
-                      class="group flex flex-col justify-between border border-white/10 bg-white/5 p-6 transition-colors duration-300 hover:bg-white/10"
-                    >
-                      <div class="space-y-3">
-                        <h3
-                          class="text-base font-semibold"
-                          style={`color: ${blogTitleColors[index % blogTitleColors.length]};`}
-                        >
-                          {post.data.title}
-                        </h3>
-                        <p class="text-sm text-[#FAFAFA]/60">
-                          {post.data.description}
-                        </p>
-                      </div>
-                      <div class="flex items-center justify-between">
-                        <span class="text-xs text-[#FAFAFA]/50">
-                          {formatDate(post.data.date)} · {post.data.author}
-                        </span>
-                        <span class="text-sm text-[#FAFAFA]/40 inline-flex items-center gap-2 my-2">
-                          Read
-                          <ArrowRight size={14} />
-                        </span>
-                      </div>
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </section>
+          posts.map((post, index) => (
+            <BlogCard
+              href={`/blog/${post.slug}`}
+              title={post.data.title}
+              date={post.data.date}
+              author={post.data.author}
+              titleColor="#FAFAFA"
+            />
           ))
         }
       </div>
     </div>
   </Container>
 </PageLayout>
+
+<script>
+  function initTypeout() {
+    document.querySelectorAll<HTMLElement>("[data-typeout]").forEach((el) => {
+      const text = el.textContent?.trim() ?? "";
+      el.textContent = "";
+
+      const obs = new IntersectionObserver(
+        (entries) => {
+          if (entries[0].isIntersecting) {
+            obs.disconnect();
+            let i = 0;
+            (function type() {
+              if (i < text.length) {
+                el.textContent += text[i++];
+                setTimeout(type, 45);
+              }
+            })();
+          }
+        },
+        { threshold: 0.5 }
+      );
+
+      obs.observe(el);
+    });
+  }
+
+  document.addEventListener("astro:page-load", initTypeout);
+</script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,8 @@
 import { getCollection } from "astro:content";
 import Container from "@components/Container.astro";
 import PageLayout from "@layouts/PageLayout.astro";
-import Link from "@components/Link.astro";
+import BlogCard from "@components/BlogCard.astro";
+import ContactSection from "@components/ContactSection.astro";
 // import { dateRange } from "@lib/utils";
 import {
   SITE,
@@ -10,12 +11,14 @@ import {
   //LINKS
 } from "@consts";
 
-import { ArrowRight } from "@lucide/astro";
+const HOMEPAGE_BLOG_SLUGS = [
+  "01-contributing-opfs-cr-sqlite",
+  "02-workflow-developing-third-party-deps",
+];
 
 const blog = (await getCollection("blog"))
-  .filter((post) => !post.data.draft)
-  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
-  .slice(0, SITE.NUM_POSTS_ON_HOMEPAGE);
+  .filter((post) => !post.data.draft && HOMEPAGE_BLOG_SLUGS.includes(post.slug))
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 
 const projects = (await getCollection("projects"))
   .filter((project) => !project.data.draft)
@@ -38,20 +41,13 @@ const services = (
 ).filter((service) => !service.data.draft);
 
 const blogTitleColors = ["#F4C45C", "#F4915C"];
-
-const formatDate = (date: Date) =>
-  new Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "2-digit",
-    year: "numeric",
-  }).format(date);
 ---
 
 <PageLayout title={HOME.TITLE} description={HOME.DESCRIPTION}>
   <Container>
-    <div class="space-y-24">
-      <section id="hero" class="space-y-6">
-        <h1 class="text-3xl font-medium leading-tight text-[#FAFAFA]">
+    <div class="space-y-20">
+      <section id="hero" class="space-y-3">
+        <h1 class="text-4xl font-bold leading-tight text-[#FAFAFA]">
           Operational systems for growing companies.
         </h1>
         <p class="text-lg text-[#7EC7FF]">
@@ -69,33 +65,40 @@ const formatDate = (date: Date) =>
             </h2>
           </div>
           {
-            services.map((service) => (
-              // when ready change to <a> w/ href={service.data.href ?? "#contact"}
-              <div class="group flex min-h-[170px] flex-col justify-between border border-white/10 bg-white/5 p-6">
-                <div class="space-y-3">
-                  <h3 class="text-xl font-medium text-[#FAFAFA]">
-                    {service.data.title}
-                  </h3>
-                  <p class="text-base text-[#FAFAFA]/60">
-                    {service.data.description}
-                  </p>
-                </div>
-                {/* <div class="mt-6 flex items-center justify-end text-[#FAFAFA]/60 transition-colors duration-300 group-hover:text-[#FAFAFA]">
-                  <span class="inline-flex size-8 items-center justify-center rounded-md border border-white/10 bg-white/5">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 24 24"
-                      class="size-4 stroke-2"
-                      fill="none"
-                      stroke="currentColor"
-                    >
-                      <line x1="5" y1="12" x2="19" y2="12" />
-                      <polyline points="12 5 19 12 12 19" />
-                    </svg>
-                  </span>
-                </div> */}
-              </div>
-            ))
+            services.map((service) => {
+              const Tag = service.data.href ? "a" : "div";
+              return (
+                <Tag
+                  href={service.data.href}
+                  class={`group flex min-h-[170px] flex-col justify-between border border-white/10 bg-white/5 p-6${service.data.href ? " transition-colors duration-300 hover:bg-white/10" : ""}`}
+                >
+                  <div class="space-y-3">
+                    <h3 class="text-xl font-medium text-[#FAFAFA]">
+                      {service.data.title}
+                    </h3>
+                    <p class="text-base text-[#FAFAFA]/60">
+                      {service.data.description}
+                    </p>
+                  </div>
+                  {service.data.href && (
+                    <div class="mt-6 flex items-center justify-end text-[#FAFAFA]/60 transition-colors duration-300 group-hover:text-[#FAFAFA]">
+                      <span class="inline-flex size-8 items-center justify-center rounded-md border border-white/10 bg-white/5">
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 24 24"
+                          class="size-4 stroke-2"
+                          fill="none"
+                          stroke="currentColor"
+                        >
+                          <line x1="5" y1="12" x2="19" y2="12" />
+                          <polyline points="12 5 19 12 12 19" />
+                        </svg>
+                      </span>
+                    </div>
+                  )}
+                </Tag>
+              );
+            })
           }
         </div>
       </section>
@@ -147,78 +150,33 @@ const formatDate = (date: Date) =>
             class="flex min-h-[170px] flex-col justify-between border border-white/10 p-6"
           >
             <h2 class="text-xl font-medium text-[#FAFAFA]/50">Blog</h2>
+            <a href="/blog" class="group inline-flex items-center gap-2 text-sm text-[#FAFAFA]/40 hover:text-[#FAFAFA] transition-colors duration-300">
+              View all
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="size-4 stroke-2 fill-none stroke-current rotate-180"
+              >
+                <line x1="5" y1="12" x2="19" y2="12" class="translate-x-2 group-hover:translate-x-0 scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-in-out" />
+                <polyline points="12 5 5 12 12 19" class="translate-x-1 group-hover:translate-x-0 transition-transform duration-300 ease-in-out" />
+              </svg>
+            </a>
           </div>
           {
             blog.map((post, index) => (
-              <a
+              <BlogCard
                 href={`/${post.collection}/${post.slug}`}
-                class="group flex min-h-[170px] flex-col justify-between border border-white/10 bg-white/5 p-6 transition-colors duration-300 hover:bg-white/10"
-              >
-                <div class="space-y-3">
-                  <span class="text-sm text-[#FAFAFA]/40 inline-flex items-center gap-2 my-2">
-                    Read
-                    <ArrowRight size={14} />
-                  </span>
-                  <h3
-                    class="text-xl font-medium"
-                    style={`color: ${blogTitleColors[index % blogTitleColors.length]};`}
-                  >
-                    {post.data.title}
-                  </h3>
-                </div>
-                <div class="mt-6 text-sm text-[#FAFAFA]/50">
-                  {formatDate(post.data.date)} · {post.data.author}
-                </div>
-              </a>
+                title={post.data.title}
+                date={post.data.date}
+                author={post.data.author}
+                titleColor={blogTitleColors[index % blogTitleColors.length]}
+              />
             ))
           }
         </div>
       </section>
 
-      <section id="contact">
-        <div class="p-6 sm:p-10">
-          <div class="space-y-6">
-            <h2 class="text-xl font-medium text-[#FAFAFA]">
-              Feeling stuck or unsure how to proceed?
-            </h2>
-            <p class="text-base font-regular text-[#FAFAFA]/60">
-              With every project, we follow a
-              <span class="italic">fixed-time, variable-scope</span>
-              approach inspired by Basecamp’s
-              <a
-                href="https://basecamp.com/shapeup"
-                target="_blank"
-                rel="noreferrer"
-                class="text-[#F4C45C] hover:text-[#F4C45C]/80"
-              >
-                Shape Up.
-              </a> Book a short 30 minute call with us to help shape and reduce the
-              scope of your problem until a sensible next step emerges. No obligation
-              beyond that. You’ll leave with a clearer framing and a concrete next
-              step, whether or not we continue working together.
-            </p>
-            <div
-              class="flex flex-wrap items-center gap-3 font-regular text-base"
-            >
-              <a
-                href="https://cal.eu/chris-de-sousa-fxpsnh/30min-shaping-call"
-                target="_blank"
-                rel="noreferrer"
-                class="inline-flex items-center justify-center bg-[#FAFAFA] px-4 py-2 text-[#0A0A0A] transition-colors duration-300 hover:bg-white/80"
-              >
-                Start a conversation
-              </a>
-              <a
-                href="mailto:team@codemyriad.io"
-                class="text-[#FAFAFA]/60 hover:text-[#FAFAFA] hover:underline"
-              >
-                or drop us an
-                <span class="text-[#F4C45C]">email</span>.
-              </a>
-            </div>
-          </div>
-        </div>
-      </section>
+      <ContactSection />
     </div>
   </Container>
 </PageLayout>

--- a/src/pages/projects/[...slug].astro
+++ b/src/pages/projects/[...slug].astro
@@ -29,19 +29,19 @@ const { Content } = await project.render();
     </div>
     <div class="space-y-1 my-10">
       <div class="animate flex items-center gap-1.5">
-        <div class="font-base text-sm">
+        <div class="font-base text-sm text-[#7ec7ff]">
           <FormattedDate date={project.data.date} />
         </div>
         &bull;
-        <div class="font-base text-sm">
+        <div class="font-base text-sm text-[#7ec7ff]">
           {readingTime(project.body)}
         </div>
         &bull;
-        <div class="font-base text-sm">
+        <div class="font-base text-sm text-[#7ec7ff]">
           {project.data.author}
         </div>
       </div>
-      <div class="animate text-2xl font-semibold text-black dark:text-white">
+      <div class="animate text-4xl leading-[120%] font-semibold text-white">
         {project.data.title}
       </div>
       {

--- a/src/pages/services/internal-tools.astro
+++ b/src/pages/services/internal-tools.astro
@@ -1,0 +1,237 @@
+---
+import { getCollection } from "astro:content";
+import Container from "@components/Container.astro";
+import PageLayout from "@layouts/PageLayout.astro";
+import BlogCard from "@components/BlogCard.astro";
+import ContactSection from "@components/ContactSection.astro";
+import VideoPlayer from "@components/VideoPlayer.astro";
+
+const allBlog = (await getCollection("blog")).filter((post) => !post.data.draft);
+const blogMap = Object.fromEntries(allBlog.map((post) => [post.slug, post]));
+
+const getPost = (slug: string) => blogMap[slug];
+---
+
+<PageLayout
+  title="Internal Tools"
+  description="Custom internal tools that replace spreadsheets, workarounds, and brittle automation. Built around how work actually gets done."
+>
+  <Container>
+    <div class="space-y-20 py-8">
+
+      <!-- Page header -->
+      <section class="space-y-3">
+        <h1 data-typeout class="text-6xl font-bold leading-tight text-[#FAFAFA]">
+          Internal Tools
+        </h1>
+        <p data-typeout class="text-base text-[#7EC7FF]">Automation · Reporting · Client Portals · Dashboards</p>
+      </section>
+
+      <!-- Problem statement -->
+      <section data-fade class="grid gap-x-12 md:grid-cols-6">
+        <div class="space-y-5 md:col-span-4">
+          <h2 class="text-2xl font-medium leading-snug text-[#FAFAFA]">
+            Are the spreadsheets that built your business starting to slow you down?
+          </h2>
+          <p class="text-base leading-relaxed text-body">
+            Most growing teams are running on processes that were never really designed. A spreadsheet here, a manual export there, a workflow that only one person truly understands. It holds together, until it doesn't.
+          </p>
+          <p class="text-base leading-relaxed text-body">
+            We build the tools that replace them. Not generic software you'll have to reshape your processes around — tools built specifically for how your business already works.
+          </p>
+        </div>
+      </section>
+
+      <!-- Workflow Automation -->
+      <section data-fade class="space-y-6">
+        <h3 class="text-2xl font-medium text-[#FAFAFA]">Workflow Automation</h3>
+        <div class="grid gap-x-12 gap-y-8 items-start md:grid-cols-6">
+          <div class="space-y-5 md:col-span-4">
+            <p class="text-base leading-relaxed text-body">
+              There are tasks in your business that have to happen — weekly, monthly, every time a new client comes on board — that consume hours your team could spend on something more important. Not because they're complex, but because nobody has ever sat down and built a proper way to do them.
+            </p>
+            <p class="text-base leading-relaxed text-body">
+              The routine looks like this: pull data from here, paste it over there, cross-check it against something else, format it up, send it out. Every time, by hand. The work isn't difficult — it's just inescapable. And for a founder or director wearing multiple hats, that's exactly the problem.
+            </p>
+            <p class="text-base leading-relaxed text-body">
+              We take these processes and build them properly. A tool that picks up the data, performs the work, delivers a finished output — without someone having to sit in the middle of it every time. The hours go back to your team. The error rate goes away. And the ceiling that was quietly limiting how much you could take on lifts.
+            </p>
+          </div>
+          {
+            getPost("manual-process-cost") && (
+              <div class="md:col-span-2">
+                <BlogCard
+                  href="/blog/manual-process-cost"
+                  title={getPost("manual-process-cost")!.data.title}
+                  date={getPost("manual-process-cost")!.data.date}
+                  author={getPost("manual-process-cost")!.data.author}
+                  titleColor="#F4C45C"
+                  label="Read also"
+                />
+              </div>
+            )
+          }
+        </div>
+      </section>
+
+      <!-- Owned Tools -->
+      <section data-fade class="space-y-6">
+        <h3 class="text-2xl font-medium text-[#FAFAFA]">Owned Tools</h3>
+        <div class="grid gap-x-12 gap-y-8 items-start md:grid-cols-6">
+          <div class="space-y-5 md:col-span-4">
+            <p class="text-base leading-relaxed text-body">
+              Off-the-shelf software is built for the average business — which means it's a reasonable fit for everyone and a perfect fit for no one. You end up paying for features you don't use and working around the things it can't do.
+            </p>
+            <p class="text-base leading-relaxed text-body">
+              The alternative isn't always another SaaS subscription. Sometimes it's a tool built once, for exactly your needs, that you own completely. No monthly per-seat fees that quietly compound as you hire. No vendor changing the pricing model. No risk of a third party going out of business or keeping a feature you rely on.
+            </p>
+            <p class="text-base leading-relaxed text-body">
+              We build on open source foundations, which means whatever we build, you own — no renewal conversation, no lock-in, no licence that has to follow every new hire. Far leaner at the point where per-seat costs are adding up, or where a generic tool has never quite done the job. This is often the smarter, cheaper long-term decision. You get exactly what you need, and nothing you don't.
+            </p>
+          </div>
+          {
+            getPost("saas-subscription-worth-it") && (
+              <div class="md:col-span-2">
+                <BlogCard
+                  href="/blog/saas-subscription-worth-it"
+                  title={getPost("saas-subscription-worth-it")!.data.title}
+                  date={getPost("saas-subscription-worth-it")!.data.date}
+                  author={getPost("saas-subscription-worth-it")!.data.author}
+                  titleColor="#F4915C"
+                  label="Read also"
+                />
+              </div>
+            )
+          }
+        </div>
+      </section>
+
+      <!-- Case Studies -->
+      <section class="space-y-16">
+        <div class="border-t border-white/10 pt-4">
+        <h1 data-typeout class="text-base font-medium text-[#FAFAFA]/40">/ Case Studies</h1>
+        </div>
+
+        <!-- Case study 1: Sales Demo Tool — no blog card -->
+        <div data-fade class="space-y-6 pb-4">
+          <div class="flex flex-col items-baseline gap-1.5">
+            <h3 class="text-3xl font-medium text-[#FAFAFA]">Sales Demo Tool</h3>
+            <span class="text-base text-body/40">
+              Client / <a href="https://whatisedible.com/" target="blank" class="text-[#7EC7FF] hover:text-[#7EC7FF]/80">Edible</a>
+            </span>
+          </div>
+          <VideoPlayer src="/videos/sales-tool-demo.webm" />
+          <div class="grid gap-x-12 md:grid-cols-6">
+            <div class="space-y-5 md:col-span-4">
+              <p class="text-base leading-relaxed text-body">
+                Edible is an online allergy menu builder for restaurants and cafes. When it came to cold outreach, founder Alex noticed that sharing a working demo of a prospect's own menu was far more effective than any description of the product. Show, don't tell — their real menu, already built in the product, sent before the first conversation.
+              </p>
+              <p class="text-base leading-relaxed text-body">
+                The problem was the process behind it. Building each demo meant manually parsing menu files, reformatting the data, and constructing everything from scratch. One demo could take hours. The approach was working, but the time it required was directly capping how many prospects could be in the pipeline at once.
+              </p>
+              <p class="text-base leading-relaxed text-body">
+                Codemyriad built a workflow that does the heavy lifting. It ingests a restaurant's existing menu files (like a print menu and allergen spreadsheet), processes the data using Optical Character Recognition (OCR), and generates a demo-ready output.
+              </p>
+              <p class="text-base leading-relaxed text-body">
+                What used to take hours became a review and a send. The sales process didn't change. The ceiling on it did.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Case study 2: Property Rental Reports / Aire Spaces — with blog card -->
+        <div data-fade class="space-y-6">
+          <div class="flex flex-col items-baseline gap-1.5">
+            <h3 class="text-3xl font-medium text-[#FAFAFA]">Property Rental Reports</h3>
+            <span class="text-base text-body/40">
+              Client / <a href="https://airespaces.co.uk/" target="blank" class="text-[#7EC7FF] hover:text-[#7EC7FF]/80">Aire Spaces</a>
+            </span>
+          </div>
+          <VideoPlayer src="/videos/property-report.webm" />
+          <div class="grid gap-x-12 gap-y-8 items-start md:grid-cols-6">
+            <div class="space-y-5 md:col-span-4">
+              <p class="text-base leading-relaxed text-body">
+                Aire Spaces manages a growing portfolio of short-term rental properties. Each month, client reporting had to be produced by hand: pulling operational data, checking it, formatting it into something presentable, and getting it out to clients — for every property, every month. As the client base grew, so did the reporting workload. More clients meant more hours spent on a manual process that was also becoming harder to keep error-free.
+              </p>
+              <p class="text-base leading-relaxed text-body">
+                We built a web application that takes existing data and turns it into complete monthly client reports — automatically. No change to how data is collected. No new process to learn. Reports generate from existing data, historical views build themselves over time, and clients receive them as a web page or a downloadable PDF. The monthly manual process is gone. The time it was consuming is back.
+              </p>
+            </div>
+            {
+              getPost("report-takes-all-day") && (
+                <div class="md:col-span-2">
+                  <BlogCard
+                    href="/blog/report-takes-all-day"
+                    title={getPost("report-takes-all-day")!.data.title}
+                    date={getPost("report-takes-all-day")!.data.date}
+                    author={getPost("report-takes-all-day")!.data.author}
+                    titleColor="#9499FF"
+                    label="Read also"
+                  />
+                </div>
+              )
+            }
+          </div>
+        </div>
+      </section>
+
+      <ContactSection />
+    </div>
+  </Container>
+</PageLayout>
+
+<script>
+  function initTypeout() {
+    document.querySelectorAll<HTMLElement>("[data-typeout]").forEach((el) => {
+      const text = el.textContent?.trim() ?? "";
+      el.textContent = "";
+
+      const obs = new IntersectionObserver(
+        (entries) => {
+          if (entries[0].isIntersecting) {
+            obs.disconnect();
+            let i = 0;
+            (function type() {
+              if (i < text.length) {
+                el.textContent += text[i++];
+                setTimeout(type, 45);
+              }
+            })();
+          }
+        },
+        { threshold: 0.5 }
+      );
+
+      obs.observe(el);
+    });
+  }
+
+  function initFadeUp() {
+    document.querySelectorAll<HTMLElement>("[data-fade]").forEach((el) => {
+      el.classList.add("fade-up");
+
+      const obs = new IntersectionObserver(
+        (entries) => {
+          if (entries[0].isIntersecting) {
+            obs.disconnect();
+            // Double rAF ensures the opacity:0 state is painted before
+            // the transition plays — fixes above-the-fold elements
+            requestAnimationFrame(() => {
+              requestAnimationFrame(() => {
+                el.classList.add("visible");
+              });
+            });
+          }
+        },
+        { threshold: 0.1 }
+      );
+
+      obs.observe(el);
+    });
+  }
+
+  document.addEventListener("astro:page-load", () => {
+    initTypeout();
+    initFadeUp();
+  });
+</script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,6 +5,7 @@
 html {
   overflow-y: scroll;
   color-scheme: dark;
+  scroll-behavior: smooth;
 }
 
 section[id] {
@@ -24,8 +25,8 @@ body {
 
 header {
   @apply fixed top-0 left-0 right-0 z-50 py-5;
-  @apply bg-[#0A0A0A]/85;
-  @apply backdrop-blur-sm saturate-200;
+  @apply bg-[#0A0A0A]/70;
+  @apply backdrop-blur-md saturate-200;
 }
 
 main {
@@ -40,17 +41,22 @@ article {
   @apply max-w-full prose prose-invert prose-img:mx-auto prose-img:my-auto;
   @apply prose-headings:font-semibold;
   @apply prose-headings:text-[#FAFAFA];
+  @apply prose-hr:border-white/10;
 }
 
 @layer utilities {
+  .text-body {
+    color: rgb(250 250 250 / 0.75);
+  }
+
   article a {
-    @apply font-sans text-current underline underline-offset-2;
-    @apply decoration-white/30;
+    @apply font-sans text-[#7ec7ff] underline underline-offset-2;
+    @apply decoration-[#7ec7ff]/50;
     @apply transition-colors duration-300 ease-in-out;
   }
   article a:hover {
-    @apply text-[#FAFAFA];
-    @apply decoration-white/50;
+    @apply text-[#7ec7ff];
+    @apply decoration-[#7ec7ff];
   }
 }
 
@@ -61,6 +67,25 @@ article {
 
 .animate.show {
   @apply opacity-100 translate-y-0;
+}
+
+@keyframes fade-up-in {
+  from {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.fade-up {
+  opacity: 0;
+}
+
+.fade-up.visible {
+  animation: fade-up-in 0.3s ease-out 0.3s forwards;
 }
 
 html #back-to-top {


### PR DESCRIPTION
- Add internal tools service page with case studies and video demos
- Add 7 new blog articles with related reading, author Chris De Sousa
- Add BlogCard, VideoPlayer, and ContactSection components
- Add blog index with 3-column grid and typeout heading animation
- Add related reading section on blog article pages with BlogCard grid
- Add ContactSection to blog article pages
- Improve blog/project article pages: white title, 4xl, blue metadata
- Style article links as #7ec7ff with matching underline
- Move back-to-top button inline with footer copyright row
- Add smooth scroll and animated arrows (view all, blog cards)
- Limit homepage blog to 2 original 2025 posts; add View all link
- Set dividers to white/10 across service and blog article pages
- Restrict service card links to Internal Tools only