### PR TITLE
enh/services

### DIFF
--- a/planning/d-341-services-comms/frame.md
+++ b/planning/d-341-services-comms/frame.md
@@ -1,0 +1,44 @@
+---
+shaping: true
+---
+
+# Services Comms — Frame
+
+**Linear:** [D-341](https://linear.app/code-myriad/issue/D-341/services-comms-codemyriadio)
+
+## Source
+
+> Codemyraid has a lead in the healthcare medical device procurement industry. The lead was sourced at the Accelerate Tomorrow Ai Summit 2026 in Berlin. Expecting that the lead will share codemyraid website around stakeholders at the organisation, it is a good time to take a look at some key areas that still need work.
+>
+> 1. Services page, and section on home hero. Right now these are cards, but I think this would do better as an informative interactive list. Mockup TBD.
+
+🟡 **D-341 updated (2026-06-12) — mockup no longer TBD, requirements expanded:**
+
+> 1. Services page and section on homehero. Right now these are cards, but I think this would do better as an informative interactive list with tabs for Services and How We Work. Ref: V8 on the Codemyraid.io Paper file.
+> 2. Important to investigate current state, and extend the sites CMS setup using markdown files (i.e how is service cards content controlled)
+> 3. It is important to consider keyboard navigation, which is a founding design principal of codemyriad.io site.
+> 4. Ensure mobile usability
+> 5. Check for any test breakage once the work package is complete.
+
+🟡 **Alex, in session (2026-06-12), on the v8 mockup's expanded row:**
+
+> just a note that the open state is shown in the design, this is a static view of an interactive component. It should not be open by default, each row should be closed by default interactive.
+
+---
+
+## Problem
+
+The Services section on the homepage and the Services index page currently use a card grid that communicates titles + one-line descriptions only. With a high-stakes lead (healthcare medical device procurement) likely to share the site with internal stakeholders, the current cards under-sell the depth and applicability of what Codemyriad does — they read as labels, not as a guided way to understand the offering.
+
+## Outcome
+
+A first-time visitor — particularly a non-technical stakeholder being passed the link by a champion inside the org — can scan the services, drill into the ones relevant to them, and leave with a clearer sense of *what Codemyriad does* and *whether it fits their situation* than the current card grid affords.
+
+---
+
+## Where this lives in the site
+
+- **Homepage** — `src/pages/index.astro`, the `#services` section (card grid driven by `services` content collection).
+- **Services index** — `src/pages/services/index.astro` (currently a placeholder list with a TODO for full design pass).
+- **Services detail (one exists)** — `src/pages/services/internal-tools.astro`.
+- **Content collection** — `src/content/services/*.md` (4 entries: local-first architecture, internal tools that fit, short feedback loops, right-sized infrastructure).

--- a/planning/d-341-services-comms/shaping.md
+++ b/planning/d-341-services-comms/shaping.md
@@ -1,0 +1,247 @@
+---
+shaping: true
+---
+
+# Services Comms — Shaping
+
+**Linear:** [D-341](https://linear.app/code-myriad/issue/D-341/codemyriadio-services)
+**Frame:** [frame.md](./frame.md)
+**Slices:** [slices.md](./slices.md)
+
+🟡 **Status (2026-06-12):** Shape **D** (the v8 Paper mockup — tabbed editor list) is **selected**. It resolves the A-vs-B-vs-C debate by keeping both axes: Shape A's offerings become the **Services** tab, and A2's "how we work" strip is promoted to a co-equal **How we work** tab. A/B/C are kept below as the audit trail.
+
+## Requirements (R)
+
+| ID | Requirement | Status |
+|----|-------------|--------|
+| R0 | Communicate Codemyriad's services more informatively than the current card grid, on both the homepage section and the Services index page | Core goal |
+| **R1** | **Audience fit** | |
+| R1.1 | Readable by non-technical stakeholders who get the link forwarded by an internal champion (e.g. healthcare-procurement lead's wider team) | Must-have |
+| R1.2 | Target a "Big Fish" tier (e.g. the healthcare medical-equipment buyer Silvio met) — not Aire-Spaces-size | Leaning yes |
+| R1.3 | Tech-proficiency target — embed with technical teams? speak to under-resourced technical leads? non-technical ops? startup CTOs needing backup? | Undecided |
+| **R2** | **Grid coherence** | |
+| R2 | The items should sit on one consistent axis — either *what we build* or *how we build* — not mix the two | Must-have |
+| **R3** | **Coverage — surface what's currently invisible** | |
+| R3.1 | Integrations & data sync (Hostaway, Librocco inventory↔ecommerce) — the homepage hero already promises "connective tissue" but no card names it | Must-have |
+| R3.2 | AI enablement — preferred framing over "AI & agents in workflow"; covers boring-foundations work, niche-wedge strategy, and ground-up workflow redesign | Must-have |
+| R3.3 | "Software you own" thread — open-source foundations, no per-seat lock-in, self-hosted (Cassini, Owned Tools section) | Leaning yes |
+| R3.4 | Built, hosted, and looked after — the ongoing-relationship half (Aire Spaces managed, Il Libraio infra) | Leaning yes |
+| **R4** | **Delivery model — surface somewhere (card, strip, or page)** | |
+| R4.1 | Shaped, staged engagements (Aire Spaces stages, Librocco Shape Up) | Leaning yes |
+| R4.2 | Right-sized, not over-built — including "we'll talk you out of the expensive thing" (Edible JSON-not-DB, declined reconciliation build) | Leaning yes |
+| R4.3 | "We build alongside you, then hand over the loop" — same-team, not client-and-agency (Edible designer→FE arc) | Leaning yes |
+| **R5** | **Tone — confident, not humble; "we get it better than most"** (Silvio) | Must-have |
+| **R6** | **Positioning — Codemyriad navigates the changing AI landscape so the client doesn't have to** (Silvio's "that's what we're here for") | Must-have |
+| 🟡 **R7** | **Implementation (D-341 requirements 1–5 + in-session note)** | |
+| 🟡 R7.1 | Interactive list with tabs — **Services** and **How we work** — per the v8 artboards in the Codemyriad.io Paper file; replaces the card grid on the homepage and the placeholder list on `/services` | Must-have |
+| 🟡 R7.2 | Every row is **closed by default**; the expanded row in the mockup is a static view of the open state, not an initial state (Alex, in session) | Must-have |
+| 🟡 R7.3 | Content controlled via markdown files, extending the existing content-collection CMS setup (`src/content/services/*.md` pattern) | Must-have |
+| 🟡 R7.4 | Keyboard navigation is first-class and consistent with the site's existing global shortcut system (`KbdChip` + `KeyboardShortcuts`); uses numeric `1`/`2` keys for Services/How we work tabs (avoids conflicts with global `S` → Services shortcut) | Must-have |
+| 🟡 R7.5 | Mobile usability — the two-column editor row must degrade gracefully below `md`; keyboard chips already hide below `sm` | Must-have |
+| 🟡 R7.6 | No test breakage — repo has no test runner; the verification gate is `pnpm lint && pnpm build` (build = `astro check && astro build`), plus a manual keyboard/mobile pass in preview | Must-have |
+
+---
+
+## Shapes (S)
+
+### A: Offerings grid + "how we work" strip
+
+Chris's candidate. Grid axis = *what we build*. Delivery-model framings (shaped/staged, right-sized, hosted) fold into a single supporting strip beneath the grid (or an "About how we work" section).
+
+| Part | Mechanism | Flag |
+|------|-----------|:----:|
+| **A1** | **Grid: 4 offering cards (what we build)** | |
+| A1.1 | **Custom internal tools** — replace spreadsheets, manual exports, one-person workarounds; built around how the business already works. *(Existing copy carried forward.)* | |
+| A1.2 | **Integrations & data sync** — the connective tissue between the tools and data your team already relies on. *(New card. Maps to Hostaway, Librocco inventory↔ecommerce.)* | ⚠️ |
+| A1.3 | **AI enablement** — get real impact from AI by laying the foundations: clean data, integrations, and workflows redesigned around a single wedge — not AI sprinkled at the edges. *(New card. Chris's preferred framing.)* | ⚠️ |
+| A1.4 | **Software you own** — open-source foundations, no per-seat lock-in, hosted on your terms. *(New card. Cassini direction, Owned Tools thread.)* | ⚠️ |
+| **A2** | **Supporting strip: how we work** | |
+| A2.1 | Shaped in stages — each stage stands on its own with a fixed timeframe and clear deliverable | |
+| A2.2 | Right-sized — we'll talk you out of the expensive thing when it's wrong | |
+| A2.3 | Built and looked after — we host and manage what we build, on your behalf | |
+| A2.4 | Same team, not client-and-agency — we hand over the loop when you're ready | |
+| **A3** | **Homepage hero section uses the same 4 offering cards**, with the "how we work" strip omitted or condensed | |
+
+### B: "Software you own" umbrella, with instances
+
+Take Chris's strongest reframe ("Software you own — not rent") as the top-level positioning, then make the grid the *instances* underneath.
+
+| Part | Mechanism | Flag |
+|------|-----------|:----:|
+| **B1** | **Umbrella headline** — *"Software you own."* Sub-line introduces open-source foundations, no per-seat lock-in, navigated AI landscape | ⚠️ |
+| **B2** | **Grid: instances of "software you own"** | |
+| B2.1 | **Internal tools that fit** — instance: custom-built tools you own | |
+| B2.2 | **Integrations & data sync** — instance: connective tissue you own | ⚠️ |
+| B2.3 | **AI enablement** — instance: AI built into workflows you own and can navigate as the landscape shifts | ⚠️ |
+| B2.4 | **Self-hosted infra & local-first** — instance: the infrastructure layer you own (folds in current "Local-first" + "Right-sized infrastructure") | ⚠️ |
+| **B3** | **"How we work" lives on its own page or footer strip**, not in the primary grid | |
+
+### C: Principles grid (current "how" axis, completed)
+
+Path-of-least-resistance baseline. Keep the grid on the *how* axis the current cards already lean toward; move the *what* (offerings) to case studies and individual service pages.
+
+| Part | Mechanism | Flag |
+|------|-----------|:----:|
+| **C1** | **Grid: 4–5 principle cards (how we work)** — Local-first architecture · Short feedback loops · Right-sized · Shaped staged engagements · Built & looked after | |
+| **C2** | **What we build** surfaces as case studies and individual service pages linked from the principles | |
+
+### 🟡 D: Tabbed editor list (v8) — Services / How we work as tabs ✅ SELECTED
+
+The v8 Paper artboards. An editor-gutter list with a tab bar: tab 1 **Services** (Shape A's offerings, the *what* axis), tab 2 **How we work** (Shape A's A2 strip promoted to a full tab, the *how* axis). Each row is a closed accordion line (caret · index · title · one-line description) that expands in place to a longer body, with an optional "Explore …" link for services that have detail pages and a "principle, not a product" note for how-we-work items. Tabs carry `1`/`2` keyboard chips. R2's axis tension dissolves: both axes are present, but each tab sits cleanly on one.
+
+| Part | Mechanism | Flag |
+|------|-----------|:----:|
+| **D1** | **`ServicesTabs.astro` component** (new, `src/components/`) — used by both pages | |
+| 🟡 D1.1 | Tab bar: `role="tablist"` with two `role="tab"` `<button>`s, WAI-ARIA APG tabs pattern — roving `tabindex`, Left/Right/Home/End with **automatic activation** (panels are pre-rendered; instant switch matches the 1/2 chips' mental model). After any switch, if focus was inside the now-hidden panel (shortcut-driven `.click()`), focus moves to the activated tab | |
+| 🟡 D1.2 | Each tab button carries a **bespoke `<kbd data-shortcut>` chip** (`1` / `2`), `aria-hidden` with `aria-keyshortcuts` on the button. Not `KbdChip`: the v8 tab chips are `size-5`, accent-tinted, and state-driven via `aria-selected` — styling the shared chip hardcodes. `data-shortcut` keeps the global handler contract | |
+| 🟡 D1.3 | Panels: `role="tabpanel"` + `aria-labelledby={tab id}`; inactive panel gets `hidden`. **Accepted tradeoff:** without JS the second tab is unreachable (site navigation is already JS-dependent — the header menu); rows inside the visible panel still expand natively | |
+| 🟡 D1.4 | Rows: `<ol>` of `<details name="cm-acc-{tab}">` + `<summary>` per item. Native semantics: Enter/Space toggles, `name` gives native single-open-per-tab (Baseline 2024; older browsers degrade to multi-open, nothing breaks). **No `open` attribute rendered — all rows closed by default (R7.2).** Title + description are plain `<span>`s (no headings inside `summary` — it maps to role *button*); caret, index, and OPEN indicator are `aria-hidden` so the accessible name stays "title, description" | |
+| 🟡 D1.5 | Open-state styling pure CSS via `details[open]` — tinted `#7EC7FF` background/borders, left accent bar (`::before`), caret `▸`→`▾`, `● OPEN` indicator. `open:-mt-px` so the accent `border-t` overlaps the previous row's `border-b` (no 2px seam). Native markers suppressed (`list-style: none` + `::-webkit-details-marker`). Smooth transitions for accordion open/close with `transition-all` | |
+| 🟡 D1.6 | Value translation: Paper exports dynamic-spacing utilities (`py-3.25`, `w-21`, `basis-82.5`, `max-w-180`…) **and non-scale alpha modifiers** (`white/12`) that don't exist in this repo's Tailwind 3.4 default theme — translate to arbitrary values (`py-[13px]`, `w-[84px]`, `basis-[330px]`, `max-w-[720px]`, `white/[0.12]`…). The Paper JSX export is the build-time source of truth for dimensions; the affordance table below is a summary | |
+| 🟡 D1.7 | Typography: the design's JetBrains Mono **Medium (500)** is not loaded by the site (400/600 only — every existing `font-medium` silently renders 400). Add `@fontsource/jetbrains-mono/latin-500.css` + woff2 preload in `Head.astro`, matching the 400/600 pattern. Conscious side effect: existing `font-medium` usages site-wide (card titles etc.) now render true Medium — aligns rendering with both design intent and what the code already asks for | |
+| **D2** | **Content model — second collection** (see D2 alternatives below) | |
+| D2.1 | New `how-we-work` collection: `{ title, description, note?, draft? }`; markdown **body = expanded row content** | |
+| D2.2 | `services` schema extended with `linkLabel?` (e.g. "Explore internal tools"); existing `href` becomes the link target; markdown **body = expanded row content** | |
+| D2.3 | Ordering stays the established filename-prefix convention (`01-…`, `02-…`), sorted by entry id in the component | |
+| 🟡 **D3** | **Keyboard shortcuts: numeric keys 1/2 for Services/How we work tabs** — avoids conflict with global `S` → Services navigation shortcut by using `1`/`2` instead of `S`/`H`. Three-tier precedence in `KeyboardShortcuts.astro`: **(1)** chips inside an open menu panel — resolved at *keydown* time since menu state changes at runtime; **(2)** chips inside `<main>` — **(3)** the rest, first-in-DOM. Also applies site-standard init guard (module flag) fixing the pre-existing double-listener on first load | |
+| 🟡 **D4** | **Homepage** — replace the `#services` card grid in `src/pages/index.astro` (lines 86–132) with `<ServicesTabs />`. Keep `id="services"` on the section. The "Areas of expertise" h2 disappears with the grid; the component carries an **sr-only h2** so the heading outline survives (sibling sections keep their h2s). Also delete the now-unused frontmatter `ServiceEntry` type + `getCollection("services")` block (lines 56–69) — `eslint no-unused-vars` is an error in this repo | |
+| 🟡 **D5** | **`/services` page** — replace the TODO placeholder list in `src/pages/services/index.astro` with the same `<ServicesTabs />` under the existing page header, and normalize the wrapper `max-w-screen-xl` → `max-w-screen-lg` so both instances render at the same measure (the v8 artboard's component sits in a `lg` column; accepted width 1024px vs the artboard's 960px) | |
+| **D6** | **Content migration** (reference-integrity constraint: `02-fixing-brittle-internal-systems` is referenced by 4 case studies via `reference("services")`; `03-short-feedback-loops` by 1) — see migration table below | |
+| 🟡 **D7** | **Shortcut guide** — the guide's `groups` array is static and global (the "AIR" group is *titled* by page, not conditionally rendered). Follow that convention: new group **"Services list (home & /services)"** (`1` Services tab · `2` How we work tab); `aria-keyshortcuts` on the tab buttons | |
+| **D8** | **Mobile** — below `md`: title + description stack inside the row, gutter slims (`w-[84px]` → `w-14`), `KbdChip` already hides below `sm`, whole `<summary>` row is the tap target | |
+| **D9** | **Verification** — `pnpm lint && pnpm build`, then preview pass: tab/arrow/1/2 keyboard behaviour, 390px mobile layout, no-JS sanity (rows still expandable — native `<details>`) | |
+
+#### D2: Content model — alternatives
+
+| Req | Requirement | Status | D2-A: one collection + `tab` field | D2-B: second `how-we-work` collection | D2-C: hardcode how-we-work in component |
+|-----|-------------|--------|:---:|:---:|:---:|
+| R7.1 | Two-tab list, both data-driven | Must-have | ✅ | ✅ | ✅ |
+| R7.3 | Content controlled via markdown, extending existing CMS pattern | Must-have | ✅ | ✅ | ❌ |
+| — | `reference("services")` in projects/case-studies stays semantically clean (principles must not become referenceable "services") | Must-have | ❌ | ✅ | ✅ |
+
+**Notes:** D2-A pollutes the `services` reference space — case studies could reference "Right-sized" as a service. D2-C fails R7.3 outright. → **D2-B selected.**
+
+#### D3: Keyboard conflict — alternatives
+
+| Req | Requirement | Status | D3-A: main-scope precedence | D3-B: reserve S/H + dedicated listener | D3-C: different keys (1/2) |
+|-----|-------------|--------|:---:|:---:|:---:|
+| R7.4 | `1`/`2` switch tabs on pages with the component (per final implementation) | Must-have | — | — | ✅ |
+| R7.4 | `S` still navigates to `/services` from pages without the component | Must-have | ✅ | ❌ | ✅ |
+| — | Single mechanism, no parallel keymap to maintain | Nice-to-have | ✅ | ❌ | ✅ |
+
+**Notes:** D3-B's global `RESERVED` set would kill the `S` nav shortcut site-wide. **D3-C selected (final implementation)**: numeric keys `1` and `2` for Services/How we work tabs cleanly avoids conflicts, maintains single global keymap, and simplifies mental model. Requires only labeling the chips with numerals instead of letters—no design contradiction once understood as a UX-driven improvement over the v8 original.
+
+---
+
+## Fit Check
+
+| Req | Requirement | Status | A | B | C | 🟡 D |
+|-----|-------------|--------|:-:|:-:|:-:|:-:|
+| R0 | More informative than current card grid | Core goal | ✅ | ✅ | ✅ | ✅ |
+| R1.1 | Readable by non-technical stakeholders | Must-have | ✅ | ✅ | ❌ | ✅ |
+| R1.2 | Targets Big Fish tier | Leaning yes | ✅ | ✅ | ❌ | ✅ |
+| R1.3 | Tech-proficiency target named | Undecided | ❌ | ❌ | ❌ | ❌ |
+| R2 | Items on a single consistent axis | Must-have | ✅ | ✅ | ✅ | ✅ |
+| R3.1 | Integrations & data sync surfaced | Must-have | ✅ | ✅ | ❌ | ✅ |
+| R3.2 | AI enablement surfaced | Must-have | ✅ | ✅ | ❌ | ✅ |
+| R3.3 | "Software you own" thread surfaced | Leaning yes | ✅ | ✅ | ❌ | ✅ |
+| R3.4 | Built/hosted/looked after surfaced | Leaning yes | ✅ | ❌ | ✅ | ❌ |
+| R4.1 | Shaped, staged engagements surfaced | Leaning yes | ✅ | ❌ | ✅ | ✅ |
+| R4.2 | Right-sized / "talk you out of it" surfaced | Leaning yes | ✅ | ❌ | ✅ | ✅ |
+| R4.3 | Build-alongside-then-hand-over surfaced | Leaning yes | ✅ | ❌ | ❌ | ✅ |
+| R5 | Confident tone, "we get it better than most" | Must-have | ❌ | ❌ | ❌ | ✅ |
+| R6 | Navigates the changing AI landscape for the client | Must-have | ❌ | ❌ | ❌ | ✅ |
+| 🟡 R7.1 | Tabbed interactive list per v8, both pages | Must-have | ❌ | ❌ | ❌ | ✅ |
+| 🟡 R7.2 | Rows closed by default | Must-have | ❌ | ❌ | ❌ | ✅ |
+| 🟡 R7.3 | Markdown-driven content (CMS extension) | Must-have | ❌ | ❌ | ❌ | ✅ |
+| 🟡 R7.4 | Keyboard nav, no shortcut conflicts | Must-have | ❌ | ❌ | ❌ | ✅ |
+| 🟡 R7.5 | Mobile usability | Must-have | ❌ | ❌ | ❌ | ✅ |
+| 🟡 R7.6 | Lint + build pass | Must-have | ❌ | ❌ | ❌ | ✅ |
+
+**Notes:**
+- **D fails R3.4:** the v8 How-we-work tab has three items (Shaped engagements · Right-sized · Built alongside you) — the "built, hosted, and looked after" ongoing-relationship thread is absent. The D2-B content model makes this a pure content addition later (drop a `04-….md` into `how-we-work/`), no code change. Carried as an open item, not blocking.
+- **D passes R5/R6 via copy**, not structure: the v8 lines ("We'll talk you out of the expensive thing when it's wrong", "Not how a generic SaaS tool wants it to be") carry the confident register; R6 is carried by the drafted *AI in the workflow* body (below) — **drafted copy, needs Alex/Chris sign-off**.
+- **R3.2 supersession:** the earlier shaping preferred "AI enablement" as the framing; the v8 design (newer, Alex's) titles the row **"AI in the workflow"**. The design is ground truth per D-341 — flagged so the rename is a conscious choice, not a drift.
+- **R1.3 stays unresolved for all shapes** — it's a positioning decision orthogonal to this build; v8's structure (short row + expandable depth) serves any of the candidate audiences.
+- A/B/C fail R7.x structurally: static card grids, no tabs/interaction model.
+
+---
+
+## Detail D: Affordances
+
+### UI affordances (per v8 artboards, exact values from Paper JSX export)
+
+| Affordance | Where | Behaviour / key values |
+|---|---|---|
+| Tab bar | Top of component, `border-b` `white/12` | Active tab: `bg #7EC7FF12`, `border-t-2 #7EC7FF`, side borders `white/10`, `-mb-px` overlap, label `text-sm` medium `#FAFAFA`; chip `size-5 rounded-sm bg #7EC7FF24 border #7EC7FF80 text #7EC7FF text-[11px]`. Inactive: transparent top border, label/chip at `#FAFAFA66` / `border-white/15` |
+| Closed row (summary) | List, `border-b white/[0.08]` | Gutter `w-[84px] shrink-0 px-4 py-[22px] border-r white/[0.07]`: caret `▸` `#FAFAFA40` + index `01` `text-[11px] tracking-[0.12em] #FAFAFA4D`. Main: title `text-[22px] leading-[1.3]` medium `#FAFAFAD9` `basis-[330px] shrink-0`, description `text-sm leading-[1.55] #FAFAFA8C grow`, `gap-8`, baseline-aligned |
+| Open row (`details[open]`) | Same row | Container `bg #7EC7FF0F`, `border-y #7EC7FF2E`, absolute left accent bar `w-[3px] bg #7EC7FF inset-y-0`. Gutter `bg #7EC7FF0D border-r #7EC7FF40`, caret `▾` + index `#7EC7FF`. Title `#FAFAFA`, description `#FAFAFAB3`. Indicator right: `7px` dot + `OPEN` (`text-[11px] tracking-[0.12em] uppercase #7EC7FF`) + terminal cursor block `w-2 h-3.5 #7EC7FF` |
+| Expanded body | Below summary, inside details | `max-w-[720px] text-sm leading-[1.7] #FAFAFAB3`, gutter column continues (empty, tinted); body from markdown |
+| Service link | Body footer (services with `href`) | `linkLabel` text `text-[13px] #7EC7FF` with `border-b #7EC7FF80`, arrow icon 14px `currentColor` (design export shows black stroke — artifact, use currentColor) |
+| Principle note | Body footer (how-we-work) | `note` text `text-[11px] tracking-widest uppercase #FAFAFA59` |
+| Hover (not in static design) | Closed rows | Subtle `bg-white/[0.03]`, title/caret brighten, `cursor-pointer`, `transition-colors` — matches existing card hover idiom |
+| Focus | Tabs + summaries | `focus-visible` treatment per site convention (visible against dark bg) |
+
+### Non-UI affordances
+
+| Affordance | Where | Mechanism |
+|---|---|---|
+| `how-we-work` collection | `src/content/config.ts` | `{ title, description, note?, draft? }`, type "content" |
+| `services.linkLabel` | `src/content/config.ts` | optional string, pairs with existing `href` |
+| Entry render | `ServicesTabs.astro` | `getCollection` × 2, filter `draft`, sort by id, `entry.render()` → `<Content />` per row body |
+| Tab switch script | `ServicesTabs.astro` `<script>` | init-guard (`data-initialized`) + `astro:page-load` re-init, per site convention; arrow-key roving tabindex |
+| Main-scope chip precedence | `KeyboardShortcuts.astro` | chips inside `main` override same-key chips outside when building the key map |
+| Guide entries | `KeyboardShortcutGuide.astro` | new group: `S` Services tab · `H` How we work tab (shown as page-contextual, like the existing `AIR` project entry) |
+
+### Content migration (D6)
+
+🟡 **Scope note (Alex, in session):** everything in this table is a content-collection entry (`src/content/…` markdown — card/row copy only; these files generate no URLs). **No pages are deleted.** `/services/internal-tools` (`src/pages/services/internal-tools.astro`) remains as-is — the expanded "Internal tools that fit" row links to it, and it will be built out further in future. `/services` remains the grouping page for all services, rendering the tabbed list.
+
+| File | Action | Notes |
+|---|---|---|
+| `services/01-local-first-architecture.md` | 🟡 Delete | Superseded; local-first/owned themes fold into *Software you own* body |
+| `services/02-fixing-brittle-internal-systems.md` | 🟡 Keep filename (slug referenced by 4 case studies), update frontmatter description to v8 short line, add `linkLabel: Explore internal tools`, move long copy into body | Title stays "Internal tools that fit" |
+| `services/03-short-feedback-loops.md` | 🟡 Delete; remove its reference from `case-studies/03-aire-spaces/report-redesign` (keep the `02-…` ref) | Essence lives on in How-we-work bodies |
+| `services/04-making-systems-dependable.md` | 🟡 Delete | "Right-sized" essence moves to `how-we-work/02-right-sized.md` |
+| `services/01-integrations-and-data-sync.md` | 🟡 Create | v8 row 01 |
+| `services/03-ai-in-the-workflow.md` | 🟡 Create | v8 row 03 |
+| `services/04-software-you-own.md` | 🟡 Create | v8 row 04 |
+| `how-we-work/01-shaped-engagements.md` | 🟡 Create | v8 row 01 |
+| `how-we-work/02-right-sized.md` | 🟡 Create | v8 row 02 (body verbatim from design) |
+| `how-we-work/03-built-alongside-you.md` | 🟡 Create | v8 row 03 |
+
+### Copy (titles/descriptions verbatim from v8; 🟡 bodies drafted where design shows only the closed row — need sign-off)
+
+| Item | Description (closed row, from design) | Body (expanded) |
+|---|---|---|
+| Integrations & data sync | The connective tissue between your tools, teams, and workflows. | 🟡 Connect the tools and data your team already relies on. Move information between systems automatically, so the work that used to live in someone's head, inbox, or spreadsheet just happens. *(from prior shaping working-candidate)* |
+| Internal tools that fit | Replace the spreadsheets, manual exports, and one-person workarounds your growth has outgrown. | Built around how the business already works — reporting that fits your operating cycle, portals that talk to your existing stack, and small automations where they earn their keep. Not how a generic SaaS tool wants it to be. *(verbatim from design)* + link **Explore internal tools** → `/services/internal-tools` |
+| AI in the workflow | LLM extraction and agents dropped into the real work — not bolted on the side. | 🟡 Real impact from AI starts with foundations: clean data, the right integrations, and a workflow redesigned around a single wedge — not AI sprinkled at the edges. We track the landscape as it shifts so you don't have to. *(carries R6; from prior working-candidate + Silvio's framing)* |
+| Software you own | Open-source foundations, self-hosted, no per-seat lock-in. Run it on your own terms. | 🟡 Open-source foundations, hosted on your terms, with no per-seat fees that compound as you hire. Built once, for exactly your needs, and yours to keep. *(from prior working-candidate)* |
+| Shaped engagements | Each stage has a fixed timeframe and a clear deliverable, and stands on its own. | 🟡 Work is shaped before it's built: a fixed timeframe, a clear deliverable, and a stage that stands on its own. You can stop after any stage and still be holding something that works. |
+| Right-sized | We'll talk you out of the expensive thing when it's wrong. | Appetite over estimates: we shape scope to fit the time, not the other way around. JSON instead of a database when that's all it needs; the bank-feed reconciliation we decided not to build. Right-sized means we sweat what matters and skip what doesn't. *(verbatim from design)* |
+| Built alongside you | Same team, not client-and-agency. We embed, build with you, then hand over the loop. | 🟡 We work as part of your team, not across a contract. We embed with the people who do the work, build with them, and hand over the loop — code, docs, and the know-how to run it — when you're ready. |
+
+All three how-we-work entries carry `note: A principle, not a product — no page to visit` (shown on Right-sized in the design; generalises to its siblings).
+
+---
+
+## 🟡 Post-review deltas (2026-06-12, from the adversarial code-review pass)
+
+Recorded deviations from the v8 artboard / earlier spec text, all deliberate:
+
+| Delta | Reason |
+|---|---|
+| Inactive tab label + chip `/40` → `/55`; how-we-work note `/35` → `/55` | WCAG AA: the artboard alphas compute to 3.66:1 / 3.1:1 on `#0A0A0A` — below 4.5:1 for operable-control labels and informational copy. `/55` (the description token) ≈ 6:1. Gutter carets/indices stay at artboard alphas — `aria-hidden` decoration; the `<ol>` carries order semantics (`role="list"` added for WebKit) |
+| Mobile (no mobile artboard exists): gutter `w-14`, index numerals hidden below `md`, title 20px, row padding 18px | Index doesn't fit the slim gutter; 22px titles crowd 390px. Documented in a component comment |
+| Tab keydown ignores modified keys | Alt/Cmd+Arrow are browser history shortcuts — must not be hijacked while a tab has focus |
+| While the menu panel is open, only panel chips resolve (no fallthrough to page targets); while the shortcut guide is open, only its own `?` toggle resolves | Overlays are modal for shortcuts — restores the pre-change semantics where an open overlay's visible chips were the only live ones; prevents invisible tab switches and focus steals behind backdrops |
+| Closed-row hover brightens title + caret (scoped CSS) | Was spec'd in the affordance table's hover row; review caught the omission |
+| Focus-recovery uses the `activeElement === body` check as primary signal | Browsers move focus to body synchronously when a focus-containing panel is hidden; the broader condition also normalizes Safari/Firefox click-focus to match Chrome. Intentional |
+
+## Open questions (carried, none blocking the build)
+
+1. **R3.4** — add a fourth How-we-work entry ("Built, hosted, and looked after") later? Pure content addition under D2-B.
+2. **R3.2 framing** — confirm "AI in the workflow" over "AI enablement" (design supersedes earlier preference; flag, don't drift).
+3. **R1.3 / audience** — unresolved positioning question; structure accommodates any answer.
+4. **🟡 Drafted bodies** — five of seven expanded bodies are drafted (marked 🟡 above); review copy before/after merge.

--- a/planning/d-341-services-comms/slices.md
+++ b/planning/d-341-services-comms/slices.md
@@ -1,0 +1,45 @@
+---
+shaping: true
+---
+
+# Services Comms — Slices
+
+**Shaping:** [shaping.md](./shaping.md) (Shape D selected — v8 tabbed editor list)
+
+Single branch (`enh/services`), three vertical slices, each demo-able.
+
+🟡 **State note (2026-06-12):** V1 and V2 are applied in the working tree (uncommitted). The content-model half of V1 was verified against the D6 table by the plan-review pass — verify and commit rather than recreate.
+
+## V1: Content model + component, live on `/services`
+
+The whole mechanism, proven on the low-traffic page first.
+
+| Affordance | Change |
+|---|---|
+| `src/content/config.ts` | Add `how-we-work` collection; add `linkLabel?` to `services` |
+| `src/content/services/*` | Migration per shaping D6 table (keep `02-…` slug; fix `report-redesign` ref) |
+| `src/content/how-we-work/*` | 3 new entries |
+| `src/components/ServicesTabs.astro` | New: tablist + panels + `<details name>` rows, closed by default; open-state CSS; 🟡 tab script: roving tabindex, Left/Right/Home/End, automatic activation, focus recovery after shortcut-driven switches (init-guard + `astro:page-load`) |
+| 🟡 `src/components/Head.astro` | Import + preload JetBrains Mono 500 (D1.7) |
+| `src/pages/services/index.astro` | Replace TODO list with `<ServicesTabs />`; 🟡 wrapper `max-w-screen-xl` → `max-w-screen-lg` (D5) |
+
+**Demo:** `/services` shows the v8 list; click rows to expand (one open per tab); tabs switch by click; build passes.
+
+## V2: Homepage swap + keyboard wiring
+
+| Affordance | Change |
+|---|---|
+| `src/pages/index.astro` | Replace `#services` grid (lines 86–132) with `<ServicesTabs />`, keep `id="services"`; 🟡 delete unused frontmatter services fetch (lines 56–69) — lint gate |
+| `src/components/KeyboardShortcuts.astro` | 🟡 Three-tier precedence (open menu panel → main → rest; D3) + init guard |
+| `src/components/KeyboardShortcutGuide.astro` | 🟡 "Services list (home & /services)" group; relabel Navigation `S` entry |
+
+**Demo:** homepage shows tabs; `S`/`H` switch tabs on home and `/services`; `S` still navigates from `/blog`; 🟡 `M` then `S` (menu open) still navigates to `/services` from the homepage; 🟡 press `H` while focus is on a services row — Tab continues from the How-we-work tab; Left/Right/Home/End move between tabs; Enter/Space toggles rows.
+
+## V3: Mobile + verification pass
+
+| Affordance | Change |
+|---|---|
+| `ServicesTabs.astro` | Responsive: stack title/description below `md`, slim gutter, indicator hidden below `sm`; 🟡 tab buttons ≥44px tall (py-[13px] + 18px label = 44px) |
+| Verification | `pnpm lint && pnpm build`; preview at 1440px and 390px; 🟡 width parity home vs `/services`; keyboard pass per V2 demo list; reduced-motion check (cursor block); 🟡 eyeball auto-close content shift at 390px (`details name`) |
+
+**Demo:** 390px viewport reads cleanly; tap targets are full rows; lint+build green.

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -1,8 +1,10 @@
 ---
 import "../styles/global.css";
 import "@fontsource/jetbrains-mono/latin-400.css";
+import "@fontsource/jetbrains-mono/latin-500.css";
 import "@fontsource/jetbrains-mono/latin-600.css";
 import jetbrainsMono400 from "@fontsource/jetbrains-mono/files/jetbrains-mono-latin-400-normal.woff2";
+import jetbrainsMono500 from "@fontsource/jetbrains-mono/files/jetbrains-mono-latin-500-normal.woff2";
 import jetbrainsMono600 from "@fontsource/jetbrains-mono/files/jetbrains-mono-latin-600-normal.woff2";
 import { ViewTransitions } from "astro:transitions";
 
@@ -31,6 +33,13 @@ const { title, description, image = "/nano.png", noindex = false } = Astro.props
 <link
   rel="preload"
   href={jetbrainsMono400}
+  as="font"
+  type="font/woff2"
+  crossorigin
+/>
+<link
+  rel="preload"
+  href={jetbrainsMono500}
   as="font"
   type="font/woff2"
   crossorigin

--- a/src/components/KeyboardShortcutGuide.astro
+++ b/src/components/KeyboardShortcutGuide.astro
@@ -25,10 +25,19 @@ const groups: Array<{ title: string; items: Item[] }> = [
     items: [
       { keys: ["~"], label: "Home (or unshifted backtick)" },
       { keys: ["M"], label: "Toggle menu" },
-      { keys: ["S"], label: "Services" },
+      // On home & /services the bare S belongs to the services list below;
+      // navigating there still works via the open menu (M, then S).
+      { keys: ["S"], label: "Services (from other pages, or via open menu)" },
       { keys: ["P"], label: "Projects" },
       { keys: ["B"], label: "Blog" },
       { keys: ["C"], label: "Contact" },
+    ],
+  },
+  {
+    title: "Services list (home & /services)",
+    items: [
+      { keys: ["1"], label: "Services tab" },
+      { keys: ["2"], label: "How we work tab" },
     ],
   },
   {

--- a/src/components/KeyboardShortcuts.astro
+++ b/src/components/KeyboardShortcuts.astro
@@ -3,23 +3,44 @@
 // elements (rendered by KbdChip) and clicks the nearest `<a>` or `<button>`
 // ancestor when the user types matching keys. The trim-from-left buffer means
 // typos like `xair` still resolve to `AIR`.
+//
+// Precedence when the same key appears more than once on a page:
+//   1. chips inside an open menu panel (resolved at keydown time — the panel
+//      visibly advertises its chips, so they must win while it's open)
+//   2. chips inside <main> (page-contextual shortcuts, e.g. the S/H tabs of
+//      the services list, which would otherwise be shadowed by the header)
+//   3. everything else, first in DOM order
 ---
 
 <script>
+  type ChipTarget = { target: HTMLElement; inMain: boolean };
+
+  // Module state persists across view transitions; `active` prevents the
+  // double-listener that init() at eval + astro:page-load would otherwise
+  // register on first load.
+  let active = false;
+
   const init = () => {
+    if (active) return;
+
     const chips = document.querySelectorAll<HTMLElement>("[data-shortcut]");
     if (!chips.length) return;
 
     // Reserved keys handled by dedicated listeners elsewhere (menu toggle, etc).
     const RESERVED = new Set(["M"]);
 
-    const map = new Map<string, HTMLElement>();
+    const map = new Map<string, ChipTarget>();
     chips.forEach((chip) => {
       const keys = chip.dataset.shortcut?.toUpperCase();
       if (!keys || RESERVED.has(keys)) return;
       const target = chip.closest<HTMLElement>("a, button");
-      if (!target || map.has(keys)) return;
-      map.set(keys, target);
+      if (!target) return;
+      const inMain = !!chip.closest("main");
+      const existing = map.get(keys);
+      // First in DOM wins, unless a later chip is main-scoped and the
+      // registered one isn't.
+      if (existing && !(inMain && !existing.inMain)) return;
+      map.set(keys, { target, inMain });
     });
     if (!map.size) return;
 
@@ -27,6 +48,40 @@
     for (const keys of map.keys()) {
       for (let i = 1; i <= keys.length; i++) prefixes.add(keys.slice(0, i));
     }
+
+    // Menu state changes at runtime, so the open-panel tier can't live in the
+    // build-time map: resolve it per keypress. While the menu is open it is
+    // modal for shortcuts — only its own chips resolve, nothing falls through
+    // to page targets behind the overlay (matches the pre-tier behavior,
+    // where every resolvable key while the menu was open was a panel chip).
+    const resolve = (keys: string): HTMLElement | undefined => {
+      if (RESERVED.has(keys)) return undefined;
+      // The shortcut guide is aria-modal: while it's open, the only shortcut
+      // allowed to resolve is its own toggle (`?` closes it again) — nothing
+      // may mutate or navigate the page behind the backdrop.
+      if (
+        document.querySelector('[data-shortcut-guide-dialog][data-open="true"]')
+      ) {
+        const target = map.get(keys)?.target;
+        return target?.matches("[data-shortcut-guide-toggle]")
+          ? target
+          : undefined;
+      }
+      const panel = document.querySelector<HTMLElement>(
+        '[data-menu-panel][data-open="true"]'
+      );
+      if (panel) {
+        for (const chip of panel.querySelectorAll<HTMLElement>(
+          "[data-shortcut]"
+        )) {
+          if (chip.dataset.shortcut?.toUpperCase() !== keys) continue;
+          const target = chip.closest<HTMLElement>("a, button");
+          if (target) return target;
+        }
+        return undefined;
+      }
+      return map.get(keys)?.target;
+    };
 
     let buffer = "";
     let timer: number | null = null;
@@ -60,7 +115,7 @@
       while (next.length && !prefixes.has(next)) next = next.slice(1);
       buffer = next;
 
-      const target = map.get(buffer);
+      const target = resolve(buffer);
       if (target) {
         reset();
         target.click();
@@ -71,10 +126,14 @@
       timer = window.setTimeout(reset, 1200);
     };
 
+    active = true;
     document.addEventListener("keydown", onKey);
     document.addEventListener(
       "astro:before-swap",
-      () => document.removeEventListener("keydown", onKey),
+      () => {
+        document.removeEventListener("keydown", onKey);
+        active = false;
+      },
       { once: true }
     );
   };

--- a/src/components/ServicesTabs.astro
+++ b/src/components/ServicesTabs.astro
@@ -1,0 +1,448 @@
+---
+// Tabbed editor list for Services / How we work (v8 design — see
+// planning/d-341-services-comms/). Used on the homepage #services section
+// and /services. One instance per page: element ids are fixed.
+//
+// Rows are native <details>/<summary> — closed by default (the open row in
+// the v8 mockup is a static view of the open state, not an initial state).
+// The `name` attribute gives native one-open-per-tab in Baseline-2024
+// browsers; older browsers simply allow multiple rows open.
+import { getCollection } from "astro:content";
+
+interface Props {
+  defaultTab?: "services" | "how-we-work";
+}
+
+const { defaultTab = "services" } = Astro.props;
+
+const serviceEntries = (await getCollection("services"))
+  .filter((entry) => !entry.data.draft)
+  .sort((a, b) => a.slug.localeCompare(b.slug));
+
+const howWeWorkEntries = (await getCollection("how-we-work"))
+  .filter((entry) => !entry.data.draft)
+  .sort((a, b) => a.slug.localeCompare(b.slug));
+
+const serviceItems = await Promise.all(
+  serviceEntries.map(async (entry) => ({
+    title: entry.data.title,
+    description: entry.data.description,
+    href: entry.data.href,
+    linkLabel: entry.data.linkLabel,
+    note: undefined as string | undefined,
+    Content: (await entry.render()).Content,
+  }))
+);
+
+const howWeWorkItems = await Promise.all(
+  howWeWorkEntries.map(async (entry) => ({
+    title: entry.data.title,
+    description: entry.data.description,
+    href: undefined as string | undefined,
+    linkLabel: undefined as string | undefined,
+    note: entry.data.note,
+    Content: (await entry.render()).Content,
+  }))
+);
+
+const tabs = [
+  { id: "services", label: "Services", key: "1", items: serviceItems },
+  { id: "how-we-work", label: "How we work", key: "2", items: howWeWorkItems },
+];
+---
+
+<div class="flex flex-col" data-services-tabs>
+  <h2 class="sr-only">Services and how we work</h2>
+
+  <div
+    role="tablist"
+    aria-label="Services and how we work"
+    class="flex border-b border-white/[0.12]"
+  >
+    {
+      tabs.map((tab) => {
+        const active = tab.id === defaultTab;
+        return (
+          <button
+            type="button"
+            role="tab"
+            id={`${tab.id}-tab`}
+            aria-selected={active ? "true" : "false"}
+            aria-controls={`${tab.id}-panel`}
+            aria-keyshortcuts={tab.key}
+            tabindex={active ? 0 : -1}
+            class:list={[
+              "group flex items-center gap-3 px-[22px] py-3 border-t-2 border-x border-b-0 transition-colors relative",
+              // /55 (not the artboard's /40): 14px medium on #0A0A0A needs
+              // ≥4.5:1 for WCAG AA — /40 computes to 3.66:1, /55 to 6:1.
+              "border-t-transparent border-x-transparent text-[#FAFAFA]/55 hover:text-[#FAFAFA]/80",
+              "aria-selected:border-t-[#7EC7FF] aria-selected:border-x-white/10 aria-selected:bg-[#7EC7FF]/[0.07] aria-selected:text-[#FAFAFA]",
+              "focus-visible:outline focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-[#7EC7FF]/60",
+            ]}
+          >
+            <span class="text-sm leading-[18px] font-medium">{tab.label}</span>
+            {/* Bespoke chip (not KbdChip): the v8 tab chips are larger and
+                accent-tinted when the tab is selected — state-driven styling
+                the shared chip doesn't model. `data-shortcut` keeps it wired
+                into the global KeyboardShortcuts handler. */}
+            <kbd
+              data-shortcut={tab.key}
+              aria-hidden="true"
+              class="hidden sm:inline-flex size-5 shrink-0 items-center justify-center rounded-sm border border-white/15 font-sans text-[11px] leading-[14px] text-[#FAFAFA]/55 transition-colors group-aria-selected:border-[#7EC7FF]/50 group-aria-selected:bg-[#7EC7FF]/[0.14] group-aria-selected:text-[#7EC7FF]"
+            >
+              {tab.key}
+            </kbd>
+          </button>
+        );
+      })
+    }
+  </div>
+
+  {
+    tabs.map((tab) => (
+      <div
+        role="tabpanel"
+        id={`${tab.id}-panel`}
+        aria-labelledby={`${tab.id}-tab`}
+        hidden={tab.id !== defaultTab}
+      >
+        {/* role=list: WebKit strips implicit list semantics from list-none */}
+        <ol role="list" class="list-none p-0 m-0 flex flex-col">
+          {tab.items.map((item, i) => (
+            <li>
+              <details
+                name={`cm-acc-${tab.id}`}
+                class:list={[
+                  "group relative border-t border-b border-white/[0.08] border-t-transparent",
+                  "open:border-t-[#7EC7FF]/[0.18] open:border-b-[#7EC7FF]/[0.18] open:bg-[#7EC7FF]/[0.06]",
+                  "before:absolute before:left-0 before:inset-y-0 before:w-[3px] before:bg-[#7EC7FF] before:opacity-0 open:before:opacity-100",
+                ]}
+              >
+                <summary class="flex transition-colors">
+                  {/* Mobile adaptations (deliberate deviations from the
+                      desktop-only v8 artboard): gutter 64px on mobile, index hidden
+                      (doesn't fit), title 20px, row padding 18px. */}
+                  <span
+                    class:list={[
+                      "flex items-baseline shrink-0 gap-2 border-r px-2.5 py-5 w-14 md:w-[84px] md:px-4",
+                      "border-white/[0.07] group-open:border-[#7EC7FF]/25 group-open:bg-[#7EC7FF]/[0.05]",
+                    ]}
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="cm-caret w-2 shrink-0 text-lg leading-4 text-[#FAFAFA]/25 group-open:text-[#7EC7FF] transition-colors"
+                    >
+                      <span class="group-open:hidden">▸</span>
+                      <span class="hidden group-open:inline">▾</span>
+                    </span>
+                    <span
+                      aria-hidden="true"
+                      class="inline text-sm leading-4 tracking-[0.12em] text-[#FAFAFA]/30 group-open:font-medium group-open:text-[#7EC7FF]"
+                    >
+                      {String(i + 1).padStart(2, "0")}
+                    </span>
+                  </span>
+                  <span
+                    class:list={[
+                      "flex grow basis-0 flex-col gap-2 py-5 pl-4 pr-4",
+                      "md:flex-row md:items-baseline md:gap-8 md:py-[22px] md:pl-7 md:pr-5",
+                    ]}
+                  >
+                    {/* Plain span, not a heading: headings inside <summary>
+                        (role button) confuse SR heading navigation. The
+                        section-level sr-only h2 carries the outline. */}
+                    <span class="cm-title shrink-0 text-xl md:text-[22px] leading-[1.3] font-medium text-[#FAFAFA]/85 md:basis-[330px] group-open:text-[#FAFAFA] transition-colors">
+                      {item.title}
+                    </span>
+                    <span class="grow basis-0 text-sm leading-[1.55] text-[#FAFAFA]/55 group-open:text-[#FAFAFA]/70">
+                      {item.description}
+                    </span>
+                  </span>
+                </summary>
+
+                <div class="flex">
+                  <span
+                    aria-hidden="true"
+                    class="w-14 shrink-0 border-r border-[#7EC7FF]/25 bg-[#7EC7FF]/[0.05] md:w-[84px]"
+                  />
+                  <div class="grow basis-0 flex md:gap-8 pb-5 pl-4 pr-4 md:pl-7 md:pr-5">
+                  <span aria-hidden="true" class="hidden md:block md:basis-[330px] shrink-0" />
+                  <div class="row-body min-w-0">
+                    <item.Content />
+                    {item.href && item.linkLabel && (
+                      <a
+                        href={item.href}
+                        class="group/link mt-4 inline-flex items-center gap-2.5 self-start"
+                      >
+                        <span class="border-b border-[#7EC7FF]/50 pb-0.5 text-[13px] leading-4 text-[#7EC7FF] transition-colors group-hover/link:border-[#7EC7FF] group-hover/link:text-[#FAFAFA]">
+                          {item.linkLabel}
+                        </span>
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 24 24"
+                          class="size-3.5 shrink-0 stroke-2 text-[#7EC7FF] transition-colors group-hover/link:text-[#FAFAFA]"
+                          fill="none"
+                          stroke="currentColor"
+                        >
+                          <line x1="5" y1="12" x2="19" y2="12" />
+                          <polyline points="12 5 19 12 12 19" />
+                        </svg>
+                      </a>
+                    )}
+                    {item.note && (
+                      /* /55 (not the artboard's /35): informational copy at
+                         11px needs AA contrast — /35 computes to ~3.1:1. */
+                      <div class="mt-3.5 text-[11px] leading-[14px] tracking-widest uppercase text-[#FAFAFA]/55">
+                        {item.note}
+                      </div>
+                    )}
+                  </div>
+                  </div>
+                </div>
+              </details>
+            </li>
+          ))}
+        </ol>
+      </div>
+    ))
+  }
+</div>
+
+<style>
+  /* Native disclosure affordances replaced by the gutter caret. */
+  summary {
+    @apply list-none cursor-pointer;
+  }
+  summary::-webkit-details-marker {
+    display: none;
+  }
+
+  details:not([open]) > summary:hover {
+    @apply bg-white/[0.07];
+  }
+  details:not([open]) > summary:hover .cm-title {
+    @apply text-[#FAFAFA];
+  }
+  details:not([open]) > summary:hover .cm-caret {
+    @apply text-[#FAFAFA]/65;
+  }
+
+  /* Suppress browser default focus ring on summary — we draw on details.
+     Both :focus and :focus-visible needed: UA fires :focus first, causing
+     a flash if only :focus-visible is suppressed. */
+  summary:focus,
+  summary:focus-visible {
+    @apply outline-none;
+  }
+
+  /* No flash: don't transition outline; scope to colour/bg only.
+     Tailwind transition-colors uses ease-in-out and includes outline —
+     both wrong here — so the transition is kept as raw CSS. */
+  details {
+    @apply outline-none;
+    transition: background-color 150ms ease-out, border-color 150ms ease-out;
+  }
+
+  /* :has() is Baseline 2023 — safe alongside <details name> (Baseline 2024). */
+  details:has(> summary:focus-visible) {
+    @apply outline outline-2 outline-[#FAFAFA]/55;
+  }
+
+  details:not([open]):has(> summary:focus-visible) > summary {
+    @apply bg-white/[0.04];
+  }
+
+  /* Expanded-row body copy comes from rendered markdown (<Content />), which
+     doesn't carry this component's scope hash — style it via :global. */
+  .row-body :global(p) {
+    @apply m-0 text-sm text-[#FAFAFA]/70;
+    line-height: 1.7; /* no Tailwind token for this value */
+  }
+  .row-body :global(p + p) {
+    @apply mt-3;
+  }
+  .row-body :global(a) {
+    @apply text-[#7EC7FF]/80 underline decoration-[#7EC7FF]/30 underline-offset-2 transition-colors hover:text-[#7EC7FF] hover:decoration-[#7EC7FF]/70;
+  }
+
+  /* Hold content visible while close animation runs (UA sets display:none on
+     details:not([open]) > :not(summary), which would cancel the animation). */
+  details.is-closing > :not(summary) {
+    display: block !important; /* !important not available via @apply in v3 */
+  }
+</style>
+
+<script>
+  // Tab switching per the WAI-ARIA APG tabs pattern: roving tabindex,
+  // Left/Right/Home/End with automatic activation (panel swap is a cheap
+  // display toggle). Same lifecycle conventions as the rest of the site:
+  // init-guard + astro:page-load re-init.
+  const init = () => {
+    document
+      .querySelectorAll<HTMLElement>("[data-services-tabs]")
+      .forEach((root) => {
+        if (root.dataset.initialized === "true") return;
+        root.dataset.initialized = "true";
+
+        const tabs = Array.from(
+          root.querySelectorAll<HTMLButtonElement>("[role='tab']")
+        );
+        const panels = Array.from(
+          root.querySelectorAll<HTMLElement>("[role='tabpanel']")
+        );
+
+        const select = (tab: HTMLButtonElement, focus = false) => {
+          tabs.forEach((t) => {
+            const active = t === tab;
+            t.setAttribute("aria-selected", active ? "true" : "false");
+            t.tabIndex = active ? 0 : -1;
+          });
+
+          const targetId = tab.getAttribute("aria-controls");
+
+          // Cancel any in-progress panel transitions so opacity is back at
+          // base before we measure state.
+          panels.forEach((p) => p.getAnimations().forEach((a) => a.cancel()));
+
+          const leaving = panels.find((p) => !p.hidden && p.id !== targetId);
+          const entering = panels.find((p) => p.id === targetId);
+
+          if (!entering) return;
+
+          // Only steal focus if it was in the panel we're about to hide.
+          const focusInLeaving = leaving
+            ? !!document.activeElement?.closest(`#${CSS.escape(leaving.id)}`)
+            : false;
+          if (focus || focusInLeaving) tab.focus();
+
+          if (!leaving) {
+            entering.hidden = false;
+            return;
+          }
+
+          leaving
+            .animate([{ opacity: 1 }, { opacity: 0 }], {
+              duration: 100,
+              easing: "ease-in",
+            })
+            .addEventListener("finish", () => {
+              leaving.hidden = true;
+              entering.hidden = false;
+              entering.animate([{ opacity: 0 }, { opacity: 1 }], {
+                duration: 180,
+                easing: "ease-out",
+              });
+            });
+        };
+
+        tabs.forEach((tab) => {
+          tab.addEventListener("click", () => select(tab));
+          tab.addEventListener("keydown", (e) => {
+            // Don't hijack browser shortcuts (Alt/Cmd+Arrow = history nav).
+            if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
+            const current = tabs.indexOf(tab);
+            let next: number | null = null;
+            if (e.key === "ArrowRight") next = (current + 1) % tabs.length;
+            else if (e.key === "ArrowLeft")
+              next = (current - 1 + tabs.length) % tabs.length;
+            else if (e.key === "Home") next = 0;
+            else if (e.key === "End") next = tabs.length - 1;
+            if (next === null) return;
+            e.preventDefault();
+            select(tabs[next], true);
+          });
+        });
+
+        // Accordion open/close animation.
+        // <details> snaps via display:none — can't be CSS-transitioned. We
+        // intercept click, prevent the native toggle, and drive height + opacity
+        // with Web Animations so open and close can run simultaneously.
+        //
+        // Easing: expo ease-out on open (snappy reveal), expo ease-in on close
+        // (quick collapse). Asymmetry matches the feel of opening vs dismissing.
+        const OPEN_OPTS = {
+          duration: 240,
+          easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+        };
+        const CLOSE_OPTS = {
+          duration: 180,
+          easing: "cubic-bezier(0.7, 0, 1, 1)",
+        };
+
+        const getBody = (det: HTMLDetailsElement) =>
+          det.querySelector<HTMLElement>(":scope > :not(summary)");
+
+        const animOpen = (det: HTMLDetailsElement) => {
+          const body = getBody(det);
+          if (!body) return;
+          // Set open first so scrollHeight is measurable, then clamp to 0
+          // before the browser paints (same synchronous task).
+          det.open = true;
+          const h = body.scrollHeight;
+          body.style.overflow = "hidden";
+          body.style.height = "0px";
+          body
+            .animate(
+              [
+                { height: "0px", opacity: "0" },
+                { height: h + "px", opacity: "1" },
+              ],
+              OPEN_OPTS
+            )
+            .addEventListener("finish", () => {
+              body.style.height = "";
+              body.style.overflow = "";
+            });
+        };
+
+        const animClose = (det: HTMLDetailsElement) => {
+          const body = getBody(det);
+          if (!body) {
+            det.open = false;
+            return;
+          }
+          const h = body.scrollHeight;
+          body.style.overflow = "hidden";
+          // .is-closing keeps content display:block while UA would set
+          // display:none after open attribute is removed.
+          det.classList.add("is-closing");
+          det.open = false;
+          body
+            .animate(
+              [
+                { height: h + "px", opacity: "1" },
+                { height: "0px", opacity: "0" },
+              ],
+              CLOSE_OPTS
+            )
+            .addEventListener("finish", () => {
+              det.classList.remove("is-closing");
+              body.style.overflow = "";
+            });
+        };
+
+        const detailsList = Array.from(
+          root.querySelectorAll<HTMLDetailsElement>("details[name]")
+        );
+
+        detailsList.forEach((det) => {
+          det.querySelector("summary")?.addEventListener("click", (e) => {
+            e.preventDefault();
+            if (det.open) {
+              animClose(det);
+            } else {
+              // Close any open peer in the same name-group simultaneously.
+              const peer = detailsList.find(
+                (d) => d !== det && d.open && d.name === det.name
+              );
+              if (peer) animClose(peer);
+              animOpen(det);
+            }
+          });
+        });
+      });
+  };
+
+  init();
+  document.addEventListener("astro:page-load", init);
+</script>

--- a/src/content/case-studies/03-aire-spaces/report-redesign/index.mdx
+++ b/src/content/case-studies/03-aire-spaces/report-redesign/index.mdx
@@ -8,7 +8,6 @@ date: 2025-09-01
 tags: ["Workflow Automation", "Reporting"]
 services:
   - 02-fixing-brittle-internal-systems
-  - 03-short-feedback-loops
 related:
   - report-takes-all-day
   - manual-process-cost

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -109,7 +109,27 @@ const services = defineCollection({
     description: z.string(),
     draft: z.boolean().optional(),
     href: z.string().optional(),
+    linkLabel: z.string().optional(), // copy for the expanded-row link to `href`
   }),
 });
 
-export const collections = { blog, projects, "case-studies": caseStudies, services };
+// Delivery principles shown on the "How we work" tab alongside services.
+// Kept separate from `services` so reference("services") stays semantically
+// clean (a principle is not a referenceable service offering).
+const howWeWork = defineCollection({
+  type: "content",
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    draft: z.boolean().optional(),
+    note: z.string().optional(), // small-caps footer line in the expanded row
+  }),
+});
+
+export const collections = {
+  blog,
+  projects,
+  "case-studies": caseStudies,
+  services,
+  "how-we-work": howWeWork,
+};

--- a/src/content/how-we-work/01-shaped-engagements.md
+++ b/src/content/how-we-work/01-shaped-engagements.md
@@ -1,0 +1,6 @@
+---
+title: Shaped engagements
+description: Fixed time, flexible scope — ship what matters.
+---
+
+Each engagement is divided into stages. You can ship or pause after each one — no mandatory follow-ons. [Shape Up](https://basecamp.com/shapeup) keeps scope from creeping and work from stalling.

--- a/src/content/how-we-work/02-right-sized.md
+++ b/src/content/how-we-work/02-right-sized.md
@@ -1,0 +1,6 @@
+---
+title: Right-sized
+description: We'll talk you out of the expensive thing when it's wrong.
+---
+
+We right-size scope to fit the timeline, not pad it. A static site instead of a CMS. JSON instead of a database. We ship what matters and leave the rest.

--- a/src/content/how-we-work/03-built-alongside-you.md
+++ b/src/content/how-we-work/03-built-alongside-you.md
@@ -1,0 +1,6 @@
+---
+title: Built alongside you
+description: Same team, not client-and-agency.
+---
+
+We embed with your team, build the work together, and hand over the code and docs when you're ready to run it yourself.

--- a/src/content/services/01-integrations-and-data-sync.md
+++ b/src/content/services/01-integrations-and-data-sync.md
@@ -1,0 +1,6 @@
+---
+title: Integrations & data sync
+description: Stop moving data by hand.
+---
+
+Link tools together — so the work that used to live in someone's head, inbox, or spreadsheet just happens.

--- a/src/content/services/01-local-first-architecture.md
+++ b/src/content/services/01-local-first-architecture.md
@@ -1,4 +1,0 @@
----
-title: Local-first architecture
-description: Low-latency interfaces that keep teams working across disconnected devices. Designed for operational environments where accuracy and uptime matter.
----

--- a/src/content/services/02-fixing-brittle-internal-systems.md
+++ b/src/content/services/02-fixing-brittle-internal-systems.md
@@ -1,5 +1,8 @@
 ---
 title: Internal tools that fit
-description: Replace the spreadsheets, manual exports, and one-person workarounds your growth has outgrown — built around how the business already works, and owned outright.
+description: Built for how you work, not how a SaaS tool wants it to.
 href: /services/internal-tools
+linkLabel: Explore internal tools
 ---
+
+When generic tools stop fitting, teams mould around them — extra steps, manual exports, one person who knows how it works. We replace that with software built specifically for the job.

--- a/src/content/services/03-ai-in-the-workflow.md
+++ b/src/content/services/03-ai-in-the-workflow.md
@@ -1,0 +1,6 @@
+---
+title: AI in the workflow
+description: Agents built in, not bolted on the side.
+---
+
+Real impact requires clean data, the right integrations, and work redesigned around one clear wedge — not AI sprinkled at the edges. We handle the plumbing so it actually does something useful.

--- a/src/content/services/03-short-feedback-loops.md
+++ b/src/content/services/03-short-feedback-loops.md
@@ -1,4 +1,0 @@
----
-title: Short feedback loops
-description: We use rapid prototyping and design-to-code workflows to explore ideas in working form early. This allows teams to make better decisions with less back-and-forth.
----

--- a/src/content/services/04-making-systems-dependable.md
+++ b/src/content/services/04-making-systems-dependable.md
@@ -1,4 +1,0 @@
----
-title: Right-sized infrastructure
-description: CI/CD and infrastructure designed for the actual scale of the problem. Reliable without unnecessary complexity or cost.
----

--- a/src/content/services/04-software-you-own.md
+++ b/src/content/services/04-software-you-own.md
@@ -1,0 +1,6 @@
+---
+title: Software you own
+description: Open-source foundations, self-hosted, no per-seat lock-in.
+---
+
+Like owning a car rather than renting one — you have the keys, the manual, and the right to customise it any way you want.

--- a/src/content/services/05-local-first-architecture.md
+++ b/src/content/services/05-local-first-architecture.md
@@ -1,0 +1,6 @@
+---
+title: Local-first architecture
+description: Keep teams working when the connection drops.
+---
+
+Data that lives on the device. Synced in the background when connectivity returns. Designed for operations where accuracy and uptime matter.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,6 +4,7 @@ import Container from "@components/Container.astro";
 import PageLayout from "@layouts/PageLayout.astro";
 import BlogCard from "@components/BlogCard.astro";
 import ContactSection from "@components/ContactSection.astro";
+import ServicesTabs from "@components/ServicesTabs.astro";
 // import { dateRange } from "@lib/utils";
 import {
   HOME,
@@ -53,21 +54,6 @@ const formatCounts = (c: { work: number; experiments: number }) => {
   return parts.join(" · ");
 };
 
-type ServiceEntry = {
-  collection: "services";
-  slug: string;
-  data: {
-    title: string;
-    description: string;
-    href?: string;
-    draft?: boolean;
-  };
-};
-
-const services = (
-  (await getCollection("services" as any)) as ServiceEntry[]
-).filter((service) => !service.data.draft);
-
 const blogTitleColors = ["#F4C45C", "#F4915C"];
 ---
 
@@ -83,52 +69,8 @@ const blogTitleColors = ["#F4C45C", "#F4915C"];
         </p>
       </section>
 
-      <section id="services" class="space-y-6">
-        <div class="grid sm:grid-cols-2 md:grid-cols-3">
-          <div
-            class="flex min-h-[170px] flex-col justify-between border border-white/10 p-6"
-          >
-            <h2 class="text-xl font-medium text-[#FAFAFA]/50">
-              Areas of expertise
-            </h2>
-          </div>
-          {
-            services.map((service) => {
-              const Tag = service.data.href ? "a" : "div";
-              return (
-                <Tag
-                  href={service.data.href}
-                  class={`group flex min-h-[170px] flex-col justify-between border border-white/10 bg-white/5 p-6${service.data.href ? " transition-colors duration-300 hover:bg-white/10" : ""}`}
-                >
-                  <div class="space-y-3">
-                    <h3 class="text-xl font-medium text-[#FAFAFA]">
-                      {service.data.title}
-                    </h3>
-                    <p class="text-base text-[#FAFAFA]/60">
-                      {service.data.description}
-                    </p>
-                  </div>
-                  {service.data.href && (
-                    <div class="mt-6 flex items-center justify-end text-[#FAFAFA]/60 transition-colors duration-300 group-hover:text-[#FAFAFA]">
-                      <span class="inline-flex size-8 items-center justify-center rounded-md border border-white/10 bg-white/5">
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          viewBox="0 0 24 24"
-                          class="size-4 stroke-2"
-                          fill="none"
-                          stroke="currentColor"
-                        >
-                          <line x1="5" y1="12" x2="19" y2="12" />
-                          <polyline points="12 5 19 12 12 19" />
-                        </svg>
-                      </span>
-                    </div>
-                  )}
-                </Tag>
-              );
-            })
-          }
-        </div>
+      <section id="services">
+        <ServicesTabs />
       </section>
 
       <section id="projects" class="space-y-6">

--- a/src/pages/services/index.astro
+++ b/src/pages/services/index.astro
@@ -1,6 +1,7 @@
 ---
 import PageLayout from "@layouts/PageLayout.astro";
 import Container from "@components/Container.astro";
+import ServicesTabs from "@components/ServicesTabs.astro";
 import { SERVICES } from "@consts";
 ---
 
@@ -10,25 +11,16 @@ import { SERVICES } from "@consts";
   breadcrumb={[{ label: "Services" }]}
 >
   <Container>
-    <div class="page-fade-in space-y-10 max-w-screen-xl mx-auto">
+    {/* max-w-screen-lg (not xl) so the list renders at the same measure as
+        the homepage instance — the v8 design's proportions assume it. */}
+    <div class="page-fade-in space-y-10 max-w-screen-lg mx-auto">
       <header class="space-y-3">
         <p class="text-base text-[#FAFAFA]/60">
           {SERVICES.DESCRIPTION}
         </p>
       </header>
 
-      <!-- TODO: full design pass. For now, a basic list of services. -->
-      <ul class="list-none p-0 space-y-3">
-        <li>
-          <a
-            href="/services/internal-tools"
-            class="inline-flex items-center gap-2 text-base text-[#7EC7FF] hover:text-[#FAFAFA] transition-colors"
-          >
-            <span>Internal Tools</span>
-            <span aria-hidden="true">→</span>
-          </a>
-        </li>
-      </ul>
+      <ServicesTabs />
     </div>
   </Container>
 </PageLayout>

--- a/src/pages/services/index.astro
+++ b/src/pages/services/index.astro
@@ -2,6 +2,7 @@
 import PageLayout from "@layouts/PageLayout.astro";
 import Container from "@components/Container.astro";
 import ServicesTabs from "@components/ServicesTabs.astro";
+import ContactSection from "@components/ContactSection.astro";
 import { SERVICES } from "@consts";
 ---
 
@@ -14,13 +15,8 @@ import { SERVICES } from "@consts";
     {/* max-w-screen-lg (not xl) so the list renders at the same measure as
         the homepage instance — the v8 design's proportions assume it. */}
     <div class="page-fade-in space-y-10 max-w-screen-lg mx-auto">
-      <header class="space-y-3">
-        <p class="text-base text-[#FAFAFA]/60">
-          {SERVICES.DESCRIPTION}
-        </p>
-      </header>
-
       <ServicesTabs />
+      <ContactSection />
     </div>
   </Container>
 </PageLayout>


### PR DESCRIPTION
The new ServicesTabs component is comprised of 5 services and 3 how we work principals.

**Services:**

1. Integrations and data sync
2. Internal tools that fit
3. AI in the workflow
4. Software you own
5. Local-first architecture

**How we work**

1. Shaped engagements
2. Right-sized
3. Built alongside you

The component is a native details accordion with WAI-ARIA tabs, Web Animations API transitions, and keyboard shortcut navigation (1/2 to switch tabs). Replaces the services card on the homepage and populates the /services page. Includes planning docs for D-341.

I reviewed all  descriptions and body copy using an accordion lens — short description earn the click, bodies pay off on open. Internal tools remains the only row that has a page clickthrough. 