### PR TITLE
Adopt shared DaisyUI design system + tokenise the site

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# codemyriad.io
+
+Public marketing site + blog for Code Myriad. Astro (astro-nano base), Tailwind v3
++ DaisyUI, TypeScript, no UI framework. `pnpm` is the package manager.
+
+## Reference docs (read the relevant one before working in that area)
+
+- **Design system / brand** → [DESIGN.md](./DESIGN.md). The brand is one file:
+  `design/theme.mjs` (DaisyUI `codemyriad` theme + JetBrains Mono), shared verbatim
+  with the private `codemyriad/proposals` repo. Style with DaisyUI tokens, never
+  hardcoded hex.
+- Internal component references live under `/lab/` (`noindex`), e.g.
+  `/lab/case-study-components`.
+
+## Conventions
+
+- Verify with `pnpm build` (`astro check && astro build`) and `pnpm lint`.
+- Don't hardcode colours — use theme tokens (`bg-base-100`, `text-primary`,
+  `text-base-content`, …).
+- Client proposals do **not** live here — they're in the private
+  `codemyriad/proposals` repo. Keep commercial/proposal content out of this public
+  repo.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,44 @@
+# Design system
+
+> Reference for anyone — human or agent — touching the visual design of this site
+> or the [proposals](https://github.com/codemyriad/proposals) decks. The brand
+> lives in one file; this explains what it is and how to change it.
+
+The brand is a small, shared layer on **Tailwind + DaisyUI**:
+
+- **`design/theme.mjs`** — the single source of truth. Exports the DaisyUI
+  `codemyriad` theme (brand palette + control-shape tokens) and `fontFamily`
+  (JetBrains Mono). `tailwind.config.mjs` imports it; nothing else defines brand
+  colours.
+- **`public/logo.svg`, `public/favicon.png`** — the mark.
+
+Everything visual is expressed as DaisyUI tokens (`bg-base-100`, `text-primary`,
+`text-base-content`, `.btn`, `.badge`, …) rather than hardcoded hex, so a brand
+change is one edit in `design/theme.mjs`.
+
+## Shared with the proposals repo
+
+`design/theme.mjs`, `public/logo.svg`, and `public/favicon.png` are **vendored
+byte-identical** into the private
+[proposals](https://github.com/codemyriad/proposals) repo (client decks build on
+the same brand). **This repo is the source of truth**; proposals keeps a copy and
+runs a weekly **design-sync** check that flags drift against these files. If you
+change the brand here, expect that check to go red until the copy is resynced —
+see the proposals repo's `DESIGN.md`.
+
+The two repos share the brand **layer only — no components**. The marketing-site
+components (`src/components/…`) and the proposal components (in the proposals repo)
+are separate surfaces.
+
+## Changing the brand
+
+1. Edit the token in **`design/theme.mjs`** (a colour, or the JetBrains Mono
+   family).
+2. `pnpm build` to confirm.
+3. Copy the changed `design/theme.mjs` (and any changed logo/favicon) into the
+   proposals repo — or let its design-sync check remind you.
+
+## Component reference
+
+DaisyUI-tokenised building blocks are documented with live examples in the
+internal `/lab/` pages (`noindex`), e.g. `/lab/case-study-components`.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@ Astro Nano is a static, minimalist, lightweight, lightning fast portfolio and bl
 
 Built with Astro, Tailwind and Typescript, an no frameworks.
 
+## 🎨 Design system
+
+The brand is one shared file — `design/theme.mjs` (the DaisyUI `codemyriad` theme
++ JetBrains Mono) — imported by `tailwind.config.mjs`. This repo is the source of
+truth; the private [proposals](https://github.com/codemyriad/proposals) repo
+vendors a byte-identical copy. See **[DESIGN.md](./DESIGN.md)**. Agent notes:
+[CLAUDE.md](./CLAUDE.md).
+
 ## 📄 Configuration
 
 The blog posts on the demo serve as the documentation and configuration.

--- a/design/theme.mjs
+++ b/design/theme.mjs
@@ -1,0 +1,48 @@
+import defaultTheme from "tailwindcss/defaultTheme";
+
+/**
+ * Code Myriad — shared brand design layer (single source of truth).
+ *
+ * Vendored into BOTH repos: codemyriad.io (marketing site) and proposals
+ * (client decks). Keep the two copies byte-identical — `make design-sync`
+ * (and the design-sync CI job) flags drift. See DESIGN.md.
+ *
+ * Consumed by each repo's tailwind.config.mjs:
+ *   import { codemyriad, fontFamily } from "./design/theme.mjs";
+ *   theme:   { extend: { fontFamily } }
+ *   daisyui: { themes: [{ codemyriad }] }
+ */
+
+// Typeface — JetBrains Mono, falling back to the platform monospace stack.
+export const fontFamily = {
+  sans: ["JetBrains Mono", ...defaultTheme.fontFamily.mono],
+};
+
+// DaisyUI theme — brand palette + control-shape tokens.
+export const codemyriad = {
+  "primary": "#38BDF8",
+  "primary-content": "#0A0A0A",
+  "secondary": "#C792EA",
+  "secondary-content": "#0A0A0A",
+  "accent": "#F4C45C",
+  "accent-content": "#0A0A0A",
+  "neutral": "#2A2A2A",
+  "neutral-content": "#FAFAFA",
+  "base-100": "#0A0A0A",
+  "base-200": "#1E1E1E",
+  "base-300": "#333333",
+  "base-content": "#FAFAFA",
+  "info": "#818CF8",
+  "info-content": "#0A0A0A",
+  "success": "#34D399",
+  "success-content": "#0A0A0A",
+  "warning": "#F4915C",
+  "warning-content": "#0A0A0A",
+  "error": "#F87171",
+  "error-content": "#0A0A0A",
+  "--rounded-btn": "0",
+  "--rounded-badge": "0",
+  "--border-btn": "1px",
+  "--animation-btn": "0.1s",
+  "--btn-focus-scale": "0.97",
+};

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@typescript-eslint/parser": "^7.3.1",
     "astro": "^4.5.6",
     "clsx": "^2.1.0",
+    "daisyui": "3",
     "eslint": "^8.57.0",
     "eslint-plugin-astro": "^0.32.0",
     "eslint-plugin-jsx-a11y": "^6.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
     dependencies:
       '@astrojs/check':
         specifier: ^0.5.9
-        version: 0.5.10(typescript@5.9.3)
+        version: 0.5.10(prettier@2.8.7)(typescript@5.9.3)
       '@astrojs/mdx':
         specifier: ^2.2.0
-        version: 2.3.1(astro@4.16.19(rollup@4.52.4)(typescript@5.9.3))
+        version: 2.3.1(astro@4.16.19(@types/node@17.0.45)(rollup@4.52.4)(typescript@5.9.3))
       '@astrojs/rss':
         specifier: ^4.0.5
         version: 4.0.12
@@ -22,13 +22,13 @@ importers:
         version: 3.6.0
       '@astrojs/tailwind':
         specifier: ^5.1.0
-        version: 5.1.5(astro@4.16.19(rollup@4.52.4)(typescript@5.9.3))(tailwindcss@3.4.18(yaml@2.8.1))
+        version: 5.1.5(astro@4.16.19(@types/node@17.0.45)(rollup@4.52.4)(typescript@5.9.3))(tailwindcss@3.4.18(yaml@2.8.1))
       '@fontsource/jetbrains-mono':
         specifier: ^5.0.17
         version: 5.2.8
       '@lucide/astro':
         specifier: ^0.563.0
-        version: 0.563.0(astro@4.16.19(rollup@4.52.4)(typescript@5.9.3))
+        version: 0.563.0(astro@4.16.19(@types/node@17.0.45)(rollup@4.52.4)(typescript@5.9.3))
       '@tailwindcss/typography':
         specifier: ^0.5.10
         version: 0.5.19(tailwindcss@3.4.18(yaml@2.8.1))
@@ -40,10 +40,13 @@ importers:
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       astro:
         specifier: ^4.5.6
-        version: 4.16.19(rollup@4.52.4)(typescript@5.9.3)
+        version: 4.16.19(@types/node@17.0.45)(rollup@4.52.4)(typescript@5.9.3)
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
+      daisyui:
+        specifier: '3'
+        version: 3.9.4(yaml@2.8.1)
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -1153,6 +1156,9 @@ packages:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
 
+  colord@2.9.3:
+    resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -1177,10 +1183,17 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-selector-tokenizer@0.8.0:
+    resolution: {integrity: sha512-Jd6Ig3/pe62/qe5SBPTN8h8LeUg/pT4lLgtavPf7updwwHpvFzxvOQBHYj2LZDMjUnBzgvIUSjRcf6oT5HzHFg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  daisyui@3.9.4:
+    resolution: {integrity: sha512-fvi2RGH4YV617/6DntOVGcOugOPym9jTGWW2XySb5ZpvdWO4L7bEG77VHirrnbRUEWvIEVXkBpxUz2KFj0rVnA==}
+    engines: {node: '>=16.9.0'}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -1457,6 +1470,9 @@ packages:
   fast-xml-parser@5.3.0:
     resolution: {integrity: sha512-gkWGshjYcQCF+6qtlrqBqELqNqnt4CxruY6UVAWWnqb3DQ6qaNFEIKqzYep1XzHLM/QtrHVCxyPOtTk4LTQ7Aw==}
     hasBin: true
+
+  fastparse@1.1.2:
+    resolution: {integrity: sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -3252,9 +3268,9 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@astrojs/check@0.5.10(typescript@5.9.3)':
+  '@astrojs/check@0.5.10(prettier@2.8.7)(typescript@5.9.3)':
     dependencies:
-      '@astrojs/language-server': 2.15.4(typescript@5.9.3)
+      '@astrojs/language-server': 2.15.4(prettier@2.8.7)(typescript@5.9.3)
       chokidar: 3.6.0
       fast-glob: 3.3.3
       kleur: 4.1.5
@@ -3268,7 +3284,7 @@ snapshots:
 
   '@astrojs/internal-helpers@0.4.1': {}
 
-  '@astrojs/language-server@2.15.4(typescript@5.9.3)':
+  '@astrojs/language-server@2.15.4(prettier@2.8.7)(typescript@5.9.3)':
     dependencies:
       '@astrojs/compiler': 2.13.0
       '@astrojs/yaml2ts': 0.2.2
@@ -3282,12 +3298,14 @@ snapshots:
       volar-service-css: 0.0.62(@volar/language-service@2.4.23)
       volar-service-emmet: 0.0.62(@volar/language-service@2.4.23)
       volar-service-html: 0.0.62(@volar/language-service@2.4.23)
-      volar-service-prettier: 0.0.62(@volar/language-service@2.4.23)
+      volar-service-prettier: 0.0.62(@volar/language-service@2.4.23)(prettier@2.8.7)
       volar-service-typescript: 0.0.62(@volar/language-service@2.4.23)
       volar-service-typescript-twoslash-queries: 0.0.62(@volar/language-service@2.4.23)
       volar-service-yaml: 0.0.62(@volar/language-service@2.4.23)
       vscode-html-languageservice: 5.5.2
       vscode-uri: 3.1.0
+    optionalDependencies:
+      prettier: 2.8.7
     transitivePeerDependencies:
       - typescript
 
@@ -3337,12 +3355,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@2.3.1(astro@4.16.19(rollup@4.52.4)(typescript@5.9.3))':
+  '@astrojs/mdx@2.3.1(astro@4.16.19(@types/node@17.0.45)(rollup@4.52.4)(typescript@5.9.3))':
     dependencies:
       '@astrojs/markdown-remark': 5.1.0
       '@mdx-js/mdx': 3.1.1
       acorn: 8.15.0
-      astro: 4.16.19(rollup@4.52.4)(typescript@5.9.3)
+      astro: 4.16.19(@types/node@17.0.45)(rollup@4.52.4)(typescript@5.9.3)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
       github-slugger: 2.0.0
@@ -3377,9 +3395,9 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.25.76
 
-  '@astrojs/tailwind@5.1.5(astro@4.16.19(rollup@4.52.4)(typescript@5.9.3))(tailwindcss@3.4.18(yaml@2.8.1))':
+  '@astrojs/tailwind@5.1.5(astro@4.16.19(@types/node@17.0.45)(rollup@4.52.4)(typescript@5.9.3))(tailwindcss@3.4.18(yaml@2.8.1))':
     dependencies:
-      astro: 4.16.19(rollup@4.52.4)(typescript@5.9.3)
+      astro: 4.16.19(@types/node@17.0.45)(rollup@4.52.4)(typescript@5.9.3)
       autoprefixer: 10.4.21(postcss@8.5.6)
       postcss: 8.5.6
       postcss-load-config: 4.0.2(postcss@8.5.6)
@@ -3762,9 +3780,9 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lucide/astro@0.563.0(astro@4.16.19(rollup@4.52.4)(typescript@5.9.3))':
+  '@lucide/astro@0.563.0(astro@4.16.19(@types/node@17.0.45)(rollup@4.52.4)(typescript@5.9.3))':
     dependencies:
-      astro: 4.16.19(rollup@4.52.4)(typescript@5.9.3)
+      astro: 4.16.19(@types/node@17.0.45)(rollup@4.52.4)(typescript@5.9.3)
 
   '@mdx-js/mdx@3.1.1':
     dependencies:
@@ -4250,7 +4268,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  astro@4.16.19(rollup@4.52.4)(typescript@5.9.3):
+  astro@4.16.19(@types/node@17.0.45)(rollup@4.52.4)(typescript@5.9.3):
     dependencies:
       '@astrojs/compiler': 2.13.0
       '@astrojs/internal-helpers': 0.4.1
@@ -4306,8 +4324,8 @@ snapshots:
       tsconfck: 3.1.6(typescript@5.9.3)
       unist-util-visit: 5.0.0
       vfile: 6.0.3
-      vite: 5.4.20
-      vitefu: 1.1.1(vite@5.4.20)
+      vite: 5.4.20(@types/node@17.0.45)
+      vitefu: 1.1.1(vite@5.4.20(@types/node@17.0.45))
       which-pm: 3.0.1
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
@@ -4486,6 +4504,8 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
 
+  colord@2.9.3: {}
+
   comma-separated-tokens@2.0.3: {}
 
   commander@4.1.1: {}
@@ -4504,7 +4524,23 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-selector-tokenizer@0.8.0:
+    dependencies:
+      cssesc: 3.0.0
+      fastparse: 1.1.2
+
   cssesc@3.0.0: {}
+
+  daisyui@3.9.4(yaml@2.8.1):
+    dependencies:
+      colord: 2.9.3
+      css-selector-tokenizer: 0.8.0
+      postcss: 8.5.6
+      postcss-js: 4.1.0(postcss@8.5.6)
+      tailwindcss: 3.4.18(yaml@2.8.1)
+    transitivePeerDependencies:
+      - tsx
+      - yaml
 
   damerau-levenshtein@1.0.8: {}
 
@@ -4905,6 +4941,8 @@ snapshots:
   fast-xml-parser@5.3.0:
     dependencies:
       strnum: 2.1.1
+
+  fastparse@1.1.2: {}
 
   fastq@1.19.1:
     dependencies:
@@ -7021,17 +7059,18 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@5.4.20:
+  vite@5.4.20(@types/node@17.0.45):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.52.4
     optionalDependencies:
+      '@types/node': 17.0.45
       fsevents: 2.3.3
 
-  vitefu@1.1.1(vite@5.4.20):
+  vitefu@1.1.1(vite@5.4.20(@types/node@17.0.45)):
     optionalDependencies:
-      vite: 5.4.20
+      vite: 5.4.20(@types/node@17.0.45)
 
   volar-service-css@0.0.62(@volar/language-service@2.4.23):
     dependencies:
@@ -7058,11 +7097,12 @@ snapshots:
     optionalDependencies:
       '@volar/language-service': 2.4.23
 
-  volar-service-prettier@0.0.62(@volar/language-service@2.4.23):
+  volar-service-prettier@0.0.62(@volar/language-service@2.4.23)(prettier@2.8.7):
     dependencies:
       vscode-uri: 3.1.0
     optionalDependencies:
       '@volar/language-service': 2.4.23
+      prettier: 2.8.7
 
   volar-service-typescript-twoslash-queries@0.0.62(@volar/language-service@2.4.23):
     dependencies:

--- a/src/components/BackToPrev.astro
+++ b/src/components/BackToPrev.astro
@@ -1,4 +1,6 @@
 ---
+import { ArrowLeft } from "@lucide/astro";
+
 type Props = {
   href: string;
 };
@@ -8,24 +10,8 @@ const { href } = Astro.props;
 
 <a
   href={href}
-  class="relative group inline-flex w-fit items-center gap-2 border border-white/10 bg-white/5 py-2 pl-8 pr-4 text-sm text-[#FAFAFA]/60 transition-colors duration-300 hover:bg-white/10 hover:text-[#FAFAFA]"
+  class="btn btn-outline btn-sm font-normal text-base-content/60"
 >
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 24 24"
-    class="absolute left-3 size-4 stroke-2 fill-none stroke-current"
-  >
-    <line
-      x1="5"
-      y1="12"
-      x2="19"
-      y2="12"
-      class="translate-x-2 group-hover:translate-x-0 scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-in-out"
-    ></line>
-    <polyline
-      points="12 5 5 12 12 19"
-      class="translate-x-1 group-hover:translate-x-0 transition-transform duration-300 ease-in-out"
-    ></polyline>
-  </svg>
+  <ArrowLeft size={14} />
   <slot />
 </a>

--- a/src/components/BackToTop.astro
+++ b/src/components/BackToTop.astro
@@ -1,18 +1,15 @@
+---
+import { ArrowUp } from "@lucide/astro";
+---
+
 <button
   id="back-to-top"
   data-visible="false"
-  class="group hidden sm:flex fixed bottom-4 right-[50px] z-40 items-center h-7 pl-8 pr-2 py-1 flex-nowrap border border-white/20 bg-black/40 backdrop-blur-sm opacity-0 pointer-events-none data-[visible=true]:opacity-100 data-[visible=true]:pointer-events-auto hover:data-[visible=true]:opacity-50 transition-all duration-300 ease-in-out hover:bg-white/10 hover:border-white/30 hover:text-[#FAFAFA]"
+  class="btn btn-outline btn-xs h-7 min-h-7 hidden sm:inline-flex fixed bottom-4 right-[50px] z-40 gap-1.5 backdrop-blur-sm bg-black/40 opacity-0 pointer-events-none data-[visible=true]:opacity-100 data-[visible=true]:pointer-events-auto transition-all duration-300 ease-in-out"
   aria-label="Back to top"
 >
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 24 24"
-    class="absolute top-1/2 left-2 -translate-y-1/2 size-4 stroke-2 fill-none stroke-current rotate-90"
-  >
-    <line x1="5" y1="12" x2="19" y2="12" class="translate-x-2 group-hover:translate-x-0 scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-in-out" />
-    <polyline points="12 5 5 12 12 19" class="translate-x-1 group-hover:translate-x-0 transition-transform duration-300 ease-in-out" />
-  </svg>
-  <span class="text-xs">Back to top</span>
+  <ArrowUp size={12} />
+  <span>Back to top</span>
 </button>
 
 <script>

--- a/src/components/BlogCard.astro
+++ b/src/components/BlogCard.astro
@@ -1,4 +1,5 @@
 ---
+import { ArrowRight } from "@lucide/astro";
 
 type Props = {
   href: string;
@@ -14,7 +15,7 @@ const {
   title,
   date,
   author,
-  titleColor = "#F4C45C",
+  titleColor = "var(--color-accent)",
   label = "Read",
 } = Astro.props;
 
@@ -28,25 +29,18 @@ const formatDate = (d: Date) =>
 
 <a
   href={href}
-  class="group flex min-h-[300px] flex-col justify-between border border-white/5 bg-white/5 p-6 transition-colors duration-300 hover:bg-white/10"
+  class="group flex min-h-[300px] flex-col justify-between border border-base-content/5 bg-white/5 p-6 transition-colors duration-300 hover:bg-white/10"
 >
   <div class="space-y-3">
-  <span class="inline-flex items-center gap-2 text-sm text-[#FAFAFA]/40">
+  <span class="inline-flex items-center gap-2 text-sm text-base-content/40">
     {label}
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      class="size-4 stroke-2 fill-none stroke-current rotate-180"
-    >
-      <line x1="5" y1="12" x2="19" y2="12" class="translate-x-2 group-hover:translate-x-0 scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-in-out" />
-      <polyline points="12 5 5 12 12 19" class="translate-x-1 group-hover:translate-x-0 transition-transform duration-300 ease-in-out" />
-    </svg>
+    <ArrowRight size={16} />
   </span>
     <h3 class="text-xl font-medium" style={`color: ${titleColor};`}>
       {title}
     </h3>
   </div>
-    <div class="text-sm text-[#FAFAFA]/50">
+    <div class="text-sm text-base-content/50">
       {formatDate(date)} · {author}
     </div>
 </a>

--- a/src/components/ContactSection.astro
+++ b/src/components/ContactSection.astro
@@ -2,7 +2,7 @@
 ---
 
 <section id="contact">
-  <div class="p-6 sm:p-10 border border-white/10">
+  <div class="p-6 sm:p-10 border border-base-300">
     <div class="space-y-6">
       <h2 class="text-2xl font-medium text-white">
         Feeling stuck or unsure how to proceed?
@@ -15,7 +15,7 @@
           href="https://basecamp.com/shapeup"
           target="_blank"
           rel="noreferrer"
-          class="text-[#F4C45C] hover:text-[#F4C45C]/80"
+          class="text-accent underline-offset-2 hover:underline hover:decoration-accent"
         >
           Shape Up.
         </a> Book a short 30 minute call with us to help shape and reduce the scope
@@ -28,17 +28,15 @@
           href="https://cal.eu/chris-de-sousa-fxpsnh/30min-shaping-call"
           target="_blank"
           rel="noreferrer"
-          class="inline-flex items-center justify-center bg-[#FAFAFA] px-4 py-2 text-[#0A0A0A] transition-colors duration-300 hover:bg-white/80"
+          class="btn border-0 bg-base-content text-base-100 hover:bg-base-content/80"
         >
           Start a conversation
         </a>
         or drop us an
         <a
           href="mailto:team@codemyriad.io"
-          class="text-body hover:text-[#FAFAFA] hover:underline decoration-[#F4C45C]"
-        >
-          <span class="text-[#F4C45C]">email</span>
-        </a>
+          class="text-accent underline-offset-2 hover:underline hover:decoration-accent"
+        >email</a>
       </div>
     </div>
   </div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -95,7 +95,7 @@ const breadcrumbShortcuts = new Map<number, string>();
       </span>
       <!-- Desktop nav (sm+) -->
       <nav
-        class="hidden order-2 md:order-3 ml-auto items-center gap-5 text-xs sm:text-sm text-[#FAFAFA]/60"
+        class="hidden order-2 md:order-3 ml-auto items-center gap-5 text-xs sm:text-sm text-base-content/60"
       >
         <Link href="/services" underline={false}>Services</Link>
         <Link href="/projects" underline={false}>Projects</Link>
@@ -109,7 +109,7 @@ const breadcrumbShortcuts = new Map<number, string>();
       <div class="relative order-2 sm:order-3 ml-auto">
         <button
           type="button"
-          class="group inline-flex items-center gap-2 text-xs leading-none uppercase tracking-widest text-[#FAFAFA]/60 hover:text-[#FAFAFA] transition-colors"
+          class="group inline-flex items-center gap-2 text-xs leading-none uppercase tracking-widest text-base-content/60 hover:text-base-content transition-colors"
           aria-label="Toggle menu (M)"
           aria-keyshortcuts="M"
           aria-controls="site-nav-menu"
@@ -128,7 +128,7 @@ const breadcrumbShortcuts = new Map<number, string>();
           aria-hidden="true"
           class:list={[
             "absolute top-full right-0 mt-2 min-w-44 z-50 p-1",
-            "bg-[#212121] border border-white/20 shadow-[0_12px_28px_rgba(0,0,0,0.45)]",
+            "bg-base-200 border border-base-content/20 shadow-[0_12px_28px_rgba(0,0,0,0.45)]",
             "backdrop-blur-md saturate-200",
             "-translate-y-2 opacity-0 pointer-events-none",
             "transition-[transform,opacity] duration-150 ease-out",
@@ -150,14 +150,14 @@ const breadcrumbShortcuts = new Map<number, string>();
                 aria-keyshortcuts={item.key}
                 class:list={[
                   "relative flex items-center justify-between gap-3 py-2 pl-5 pr-2",
-                  "text-[11px] uppercase tracking-[0.15em] text-[#FAFAFA]/60 no-underline",
+                  "text-[11px] uppercase tracking-[0.15em] text-base-content/60 no-underline",
                   "transition-colors duration-100",
                   "before:content-['>'] before:absolute before:left-2 before:top-1/2 before:-translate-y-1/2",
-                  "before:text-[#FAFAFA] before:opacity-0 before:transition-opacity before:duration-100",
-                  "hover:bg-white/10 hover:text-[#FAFAFA] hover:before:opacity-90",
-                  "focus-visible:bg-white/5 focus-visible:text-[#FAFAFA] focus-visible:outline-none focus-visible:before:opacity-90",
-                  "active:bg-white/[0.12] active:text-[#FAFAFA] active:before:opacity-100",
-                  "data-[pressed=true]:bg-white/[0.12] data-[pressed=true]:text-[#FAFAFA] data-[pressed=true]:before:opacity-100",
+                  "before:text-base-content before:opacity-0 before:transition-opacity before:duration-100",
+                  "hover:bg-white/10 hover:text-base-content hover:before:opacity-90",
+                  "focus-visible:bg-white/5 focus-visible:text-base-content focus-visible:before:opacity-90",
+                  "active:bg-white/[0.12] active:text-base-content active:before:opacity-100",
+                  "data-[pressed=true]:bg-white/[0.12] data-[pressed=true]:text-base-content data-[pressed=true]:before:opacity-100",
                 ]}
               >
                 <span>{item.label}</span>
@@ -179,7 +179,7 @@ const breadcrumbShortcuts = new Map<number, string>();
           "order-3 sm:order-2",
           "w-full sm:w-auto",
           "flex items-center gap-2 min-w-0",
-          "text-xs leading-none uppercase tracking-widest text-[#FAFAFA]/40",
+          "text-xs leading-none uppercase tracking-widest text-base-content/40",
         ]}
         aria-label="Breadcrumb"
         data-terminal-root
@@ -187,7 +187,7 @@ const breadcrumbShortcuts = new Map<number, string>();
       >
         <a
           href="/"
-          class="text-[#FAFAFA]/40 hover:text-[#FAFAFA] transition-colors shrink-0"
+          class="text-base-content/40 hover:text-base-content transition-colors shrink-0"
           data-shortcut="~"
           aria-label="Home"
           aria-keyshortcuts="~"
@@ -204,7 +204,7 @@ const breadcrumbShortcuts = new Map<number, string>();
                 {item.href && !isLast ? (
                   <a
                     href={item.href}
-                    class="hover:text-[#FAFAFA] transition-colors truncate inline-flex items-center gap-1.5"
+                    class="hover:text-base-content transition-colors truncate inline-flex items-center gap-1.5"
                     aria-label={item.label}
                   >
                     <span data-terminal-text={item.label}>{item.label}</span>
@@ -213,7 +213,7 @@ const breadcrumbShortcuts = new Map<number, string>();
                     )}
                   </a>
                 ) : (
-                  <span class="text-[#FAFAFA] truncate" aria-label={item.label}>
+                  <span class="text-base-content truncate" aria-label={item.label}>
                     <span data-terminal-text={item.label}>{item.label}</span>
                   </span>
                 )}
@@ -235,7 +235,7 @@ const breadcrumbShortcuts = new Map<number, string>();
     display: inline-block;
     width: 0.55em;
     height: 0.95em;
-    background: #fafafa;
+    background: hsl(var(--bc));
     vertical-align: -0.1em;
     margin-left: 1px;
     opacity: 0;
@@ -275,7 +275,7 @@ const breadcrumbShortcuts = new Map<number, string>();
      inherited rgba color on the parent breadcrumb nav. */
   .terminal-breadcrumb .terminal-crumb-active,
   .terminal-breadcrumb .terminal-crumb-active:hover {
-    color: #fafafa !important;
+    color: hsl(var(--bc)) !important;
   }
 
   /* Just-demoted crumb (was terminal/white, now middle/dim). Color snaps
@@ -287,10 +287,10 @@ const breadcrumbShortcuts = new Map<number, string>();
   }
   @keyframes crumb-demote {
     from {
-      color: #fafafa;
+      color: hsl(var(--bc));
     }
     to {
-      color: rgba(250, 250, 250, 0.4);
+      color: hsl(var(--bc) / 0.4);
     }
   }
   .terminal-breadcrumb a[data-just-demoted] [data-shortcut] {

--- a/src/components/KbdChip.astro
+++ b/src/components/KbdChip.astro
@@ -27,10 +27,10 @@ const chars = keys.toUpperCase().split("");
   ]}
 >
   {text ? (
-    <span class="inline-flex items-center justify-center h-3.5 px-1 font-sans text-[10px] leading-[13px] border border-white/15 bg-white/10 text-[#FAFAFA]/70 transition-colors">{keys}</span>
+    <span class="inline-flex items-center justify-center h-3.5 px-1 font-sans text-[10px] leading-[13px] border border-base-300 bg-white/10 text-base-content/70 transition-colors">{keys}</span>
   ) : (
     chars.map((ch) => (
-      <span class="inline-flex items-center justify-center w-3.5 h-3.5 font-sans text-[10px] leading-[13px] uppercase border border-white/15 bg-white/10 text-[#FAFAFA]/70 transition-colors">{ch}</span>
+      <span class="inline-flex items-center justify-center w-3.5 h-3.5 font-sans text-[10px] leading-[13px] uppercase border border-base-300 bg-white/10 text-base-content/70 transition-colors">{ch}</span>
     ))
   )}
 </kbd>

--- a/src/components/KeyboardShortcutGuide.astro
+++ b/src/components/KeyboardShortcutGuide.astro
@@ -5,7 +5,7 @@
 import { Keyboard, Terminal, X } from "@lucide/astro";
 import KbdChip from "@components/KbdChip.astro";
 
-const accent = "#7EC7FF";
+const accent = "var(--color-primary)";
 
 type Item = {
   keys: Array<string | { text: string }>;
@@ -63,7 +63,7 @@ const groups: Array<{ title: string; items: Item[] }> = [
   type="button"
   data-shortcut-guide-toggle
   data-shortcut="?"
-  class="hidden sm:inline-flex fixed bottom-4 right-4 z-40 items-center justify-center w-7 h-7 border border-white/20 bg-black/40 hover:bg-white/10 hover:border-white/30 text-[#FAFAFA]/60 hover:text-[#FAFAFA] transition-colors backdrop-blur-sm"
+  class="hidden sm:inline-flex fixed bottom-4 right-4 z-40 items-center justify-center w-7 h-7 border border-base-content/20 bg-black/40 hover:bg-white/10 hover:border-base-content/30 text-base-content/60 hover:text-base-content transition-colors backdrop-blur-sm"
   aria-label="Show keyboard shortcuts"
   aria-haspopup="dialog"
   aria-controls="shortcut-guide-dialog"
@@ -96,12 +96,12 @@ const groups: Array<{ title: string; items: Item[] }> = [
 
   <!-- Panel -->
   <div
-    class="relative w-full max-w-md bg-[#0a0a0a] border shadow-[0_12px_28px_rgba(0,0,0,0.45)]"
+    class="relative w-full max-w-md bg-base-100 border shadow-[0_12px_28px_rgba(0,0,0,0.45)]"
     style={`border-color: ${accent};`}
   >
     <header
       class="flex items-center justify-between gap-2 px-1.5 py-1.5"
-      style={`background: #0a0a0a; border-bottom: 2px solid ${accent};`}
+      style={`background: var(--color-base-100); border-bottom: 2px solid ${accent};`}
     >
       <div class="flex items-center gap-2 min-w-0">
         <Terminal size={14} color={accent} />
@@ -129,13 +129,13 @@ const groups: Array<{ title: string; items: Item[] }> = [
       {groups.map((group) => (
         <section class="space-y-2">
           <h3
-            class="text-[10px] uppercase tracking-[0.2em] text-[#FAFAFA]/40"
+            class="text-[10px] uppercase tracking-[0.2em] text-base-content/40"
           >
             {group.title}
           </h3>
           <ul class="list-none p-0 m-0 space-y-1.5">
             {group.items.map((item) => (
-              <li class="flex items-center gap-3 text-xs text-[#FAFAFA]/80">
+              <li class="flex items-center gap-3 text-xs text-base-content/80">
                 <span class="inline-flex items-center gap-1 shrink-0">
                   {item.keys.map((k) =>
                     typeof k === "string" ? (

--- a/src/components/Link.astro
+++ b/src/components/Link.astro
@@ -16,8 +16,9 @@ const { href, external, underline = true, class: className, ...rest } =
   href={href}
   target={external ? "_blank" : "_self"}
   class={cn(
-    "inline-block decoration-white/30 hover:decoration-white/50 text-current hover:text-[#FAFAFA] transition-colors duration-300 ease-in-out",
-    underline && "underline underline-offset-2",
+    "inline-block text-current hover:text-base-content transition-colors duration-300 ease-in-out",
+    "hover:underline hover:underline-offset-2 hover:decoration-base-content/30",
+    underline && "underline underline-offset-2 decoration-base-content/30",
     className
   )}
   {...rest}

--- a/src/components/ServicesTabs.astro
+++ b/src/components/ServicesTabs.astro
@@ -57,7 +57,7 @@ const tabs = [
   <div
     role="tablist"
     aria-label="Services and how we work"
-    class="flex border-b border-white/[0.12]"
+    class="flex border-b border-base-300"
   >
     {
       tabs.map((tab) => {
@@ -75,9 +75,8 @@ const tabs = [
               "group flex items-center gap-3 px-[22px] py-3 border-t-2 border-x border-b-0 transition-colors relative",
               // /55 (not the artboard's /40): 14px medium on #0A0A0A needs
               // ≥4.5:1 for WCAG AA — /40 computes to 3.66:1, /55 to 6:1.
-              "border-t-transparent border-x-transparent text-[#FAFAFA]/55 hover:text-[#FAFAFA]/80",
-              "aria-selected:border-t-[#7EC7FF] aria-selected:border-x-white/10 aria-selected:bg-[#7EC7FF]/[0.07] aria-selected:text-[#FAFAFA]",
-              "focus-visible:outline focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-[#7EC7FF]/60",
+              "border-t-transparent border-x-transparent text-base-content/55 hover:text-base-content/80",
+              "aria-selected:border-t-primary aria-selected:border-x-white/10 aria-selected:bg-primary/[0.07] aria-selected:text-base-content",
             ]}
           >
             <span class="text-sm leading-[18px] font-medium">{tab.label}</span>
@@ -88,7 +87,7 @@ const tabs = [
             <kbd
               data-shortcut={tab.key}
               aria-hidden="true"
-              class="hidden sm:inline-flex size-5 shrink-0 items-center justify-center rounded-sm border border-white/15 font-sans text-[11px] leading-[14px] text-[#FAFAFA]/55 transition-colors group-aria-selected:border-[#7EC7FF]/50 group-aria-selected:bg-[#7EC7FF]/[0.14] group-aria-selected:text-[#7EC7FF]"
+              class="hidden sm:inline-flex size-5 shrink-0 items-center justify-center rounded-sm border border-base-300 font-sans text-[11px] leading-[14px] text-base-content/55 transition-colors group-aria-selected:border-primary/50 group-aria-selected:bg-primary/[0.14] group-aria-selected:text-primary"
             >
               {tab.key}
             </kbd>
@@ -113,9 +112,9 @@ const tabs = [
               <details
                 name={`cm-acc-${tab.id}`}
                 class:list={[
-                  "group relative border-t border-b border-white/[0.08] border-t-transparent",
-                  "open:border-t-[#7EC7FF]/[0.18] open:border-b-[#7EC7FF]/[0.18] open:bg-[#7EC7FF]/[0.06]",
-                  "before:absolute before:left-0 before:inset-y-0 before:w-[3px] before:bg-[#7EC7FF] before:opacity-0 open:before:opacity-100",
+                  "group relative border-t border-b border-base-300 border-t-transparent",
+                  "open:border-t-primary/[0.18] open:border-b-primary/[0.18] open:bg-primary/[0.06]",
+                  "before:absolute before:left-0 before:inset-y-0 before:w-[3px] before:bg-primary before:opacity-0 open:before:opacity-100",
                 ]}
               >
                 <summary class="flex transition-colors">
@@ -125,19 +124,19 @@ const tabs = [
                   <span
                     class:list={[
                       "flex items-baseline shrink-0 gap-2 border-r px-2.5 py-5 w-14 md:w-[84px] md:px-4",
-                      "border-white/[0.07] group-open:border-[#7EC7FF]/25 group-open:bg-[#7EC7FF]/[0.05]",
+                      "border-base-300 group-open:border-primary/25 group-open:bg-primary/[0.05]",
                     ]}
                   >
                     <span
                       aria-hidden="true"
-                      class="cm-caret w-2 shrink-0 text-lg leading-4 text-[#FAFAFA]/25 group-open:text-[#7EC7FF] transition-colors"
+                      class="cm-caret w-2 shrink-0 text-lg leading-4 text-base-content/25 group-open:text-primary transition-colors"
                     >
                       <span class="group-open:hidden">▸</span>
                       <span class="hidden group-open:inline">▾</span>
                     </span>
                     <span
                       aria-hidden="true"
-                      class="inline text-sm leading-4 tracking-[0.12em] text-[#FAFAFA]/30 group-open:font-medium group-open:text-[#7EC7FF]"
+                      class="inline text-sm leading-4 tracking-[0.12em] text-base-content/30 group-open:font-medium group-open:text-primary"
                     >
                       {String(i + 1).padStart(2, "0")}
                     </span>
@@ -151,10 +150,10 @@ const tabs = [
                     {/* Plain span, not a heading: headings inside <summary>
                         (role button) confuse SR heading navigation. The
                         section-level sr-only h2 carries the outline. */}
-                    <span class="cm-title shrink-0 text-xl md:text-[22px] leading-[1.3] font-medium text-[#FAFAFA]/85 md:basis-[330px] group-open:text-[#FAFAFA] transition-colors">
+                    <span class="cm-title shrink-0 text-xl md:text-[22px] leading-[1.3] font-medium text-base-content/85 md:basis-[330px] group-open:text-base-content transition-colors">
                       {item.title}
                     </span>
-                    <span class="grow basis-0 text-sm leading-[1.55] text-[#FAFAFA]/55 group-open:text-[#FAFAFA]/70">
+                    <span class="grow basis-0 text-sm leading-[1.55] text-base-content/55 group-open:text-base-content/70">
                       {item.description}
                     </span>
                   </span>
@@ -163,7 +162,7 @@ const tabs = [
                 <div class="flex">
                   <span
                     aria-hidden="true"
-                    class="w-14 shrink-0 border-r border-[#7EC7FF]/25 bg-[#7EC7FF]/[0.05] md:w-[84px]"
+                    class="w-14 shrink-0 border-r border-primary/25 bg-primary/[0.05] md:w-[84px]"
                   />
                   <div class="grow basis-0 flex md:gap-8 pb-5 pl-4 pr-4 md:pl-7 md:pr-5">
                   <span aria-hidden="true" class="hidden md:block md:basis-[330px] shrink-0" />
@@ -174,13 +173,13 @@ const tabs = [
                         href={item.href}
                         class="group/link mt-4 inline-flex items-center gap-2.5 self-start"
                       >
-                        <span class="border-b border-[#7EC7FF]/50 pb-0.5 text-[13px] leading-4 text-[#7EC7FF] transition-colors group-hover/link:border-[#7EC7FF] group-hover/link:text-[#FAFAFA]">
+                        <span class="text-[13px] leading-4 text-primary">
                           {item.linkLabel}
                         </span>
                         <svg
                           xmlns="http://www.w3.org/2000/svg"
                           viewBox="0 0 24 24"
-                          class="size-3.5 shrink-0 stroke-2 text-[#7EC7FF] transition-colors group-hover/link:text-[#FAFAFA]"
+                          class="size-3.5 shrink-0 stroke-2 text-primary"
                           fill="none"
                           stroke="currentColor"
                         >
@@ -192,7 +191,7 @@ const tabs = [
                     {item.note && (
                       /* /55 (not the artboard's /35): informational copy at
                          11px needs AA contrast — /35 computes to ~3.1:1. */
-                      <div class="mt-3.5 text-[11px] leading-[14px] tracking-widest uppercase text-[#FAFAFA]/55">
+                      <div class="mt-3.5 text-[11px] leading-[14px] tracking-widest uppercase text-base-content/55">
                         {item.note}
                       </div>
                     )}
@@ -221,10 +220,10 @@ const tabs = [
     @apply bg-white/[0.07];
   }
   details:not([open]) > summary:hover .cm-title {
-    @apply text-[#FAFAFA];
+    @apply text-base-content;
   }
   details:not([open]) > summary:hover .cm-caret {
-    @apply text-[#FAFAFA]/65;
+    @apply text-base-content/65;
   }
 
   /* Suppress browser default focus ring on summary — we draw on details.
@@ -245,7 +244,7 @@ const tabs = [
 
   /* :has() is Baseline 2023 — safe alongside <details name> (Baseline 2024). */
   details:has(> summary:focus-visible) {
-    @apply outline outline-2 outline-[#FAFAFA]/55;
+    @apply outline outline-2 outline-base-content;
   }
 
   details:not([open]):has(> summary:focus-visible) > summary {
@@ -255,14 +254,14 @@ const tabs = [
   /* Expanded-row body copy comes from rendered markdown (<Content />), which
      doesn't carry this component's scope hash — style it via :global. */
   .row-body :global(p) {
-    @apply m-0 text-sm text-[#FAFAFA]/70;
+    @apply m-0 text-sm text-base-content/70;
     line-height: 1.7; /* no Tailwind token for this value */
   }
   .row-body :global(p + p) {
     @apply mt-3;
   }
   .row-body :global(a) {
-    @apply text-[#7EC7FF]/80 underline decoration-[#7EC7FF]/30 underline-offset-2 transition-colors hover:text-[#7EC7FF] hover:decoration-[#7EC7FF]/70;
+    @apply text-primary/80 underline-offset-2 transition-colors hover:text-primary hover:underline hover:decoration-primary/70;
   }
 
   /* Hold content visible while close animation runs (UA sets display:none on

--- a/src/components/VideoPlayer.astro
+++ b/src/components/VideoPlayer.astro
@@ -13,7 +13,7 @@ const { src, type = "video/webm" } = Astro.props;
 
   <!-- Overlay button — always visible, icon swaps between play/pause -->
   <div class="video-overlay absolute inset-0 flex items-center justify-center transition-opacity duration-200">
-    <div class="flex items-center justify-center w-20 h-20 rounded-full border border-white/20 bg-black/40 backdrop-blur-sm transition-all duration-200 group-hover:bg-black/60">
+    <div class="flex items-center justify-center w-20 h-20 rounded-full border border-base-content/20 bg-black/40 backdrop-blur-sm transition-all duration-200 group-hover:bg-black/60">
       <!-- Play icon -->
       <svg
         class="video-icon-play w-7 h-7 fill-white ml-1"

--- a/src/components/case-study/BeforeAfterSlider.astro
+++ b/src/components/case-study/BeforeAfterSlider.astro
@@ -24,13 +24,13 @@ const {
 ---
 
 <div class={`w-full ${className}`}>
-  <span class="text-[10px] uppercase tracking-widest text-[#FAFAFA]/40 block mb-4">
+  <span class="text-[10px] uppercase tracking-widest text-base-content/40 block mb-4">
     Before &amp; After — drag to compare
   </span>
 
   <div
     data-before-after-slider
-    class="relative w-full overflow-hidden border border-white/10 select-none bg-[#0A0A0A]"
+    class="relative w-full overflow-hidden border border-base-300 select-none bg-base-100"
     style={`aspect-ratio: ${aspectRatio};`}
     role="img"
     aria-label="Before and after comparison slider"
@@ -69,18 +69,18 @@ const {
     <div
       data-divider
       class="h-full absolute top-0 pointer-events-none"
-      style="left: 50%; transform: translateX(-50%); width: 1px; background: rgba(126,199,255,0.6);"
+      style="left: 50%; transform: translateX(-50%); width: 1px; background: color-mix(in oklch, var(--color-primary) 60%, transparent);"
     ></div>
 
     <!-- Handle -->
     <div
       data-handle
       class="flex items-center justify-center cursor-grab"
-      style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 36px; height: 36px; background: #0d0d0d; border: 1.5px solid #7EC7FF; pointer-events: none; z-index: 10;"
+      style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 36px; height: 36px; background: #0d0d0d; border: 1.5px solid var(--color-primary); pointer-events: none; z-index: 10;"
     >
       <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
-        <polyline points="7,5 4,9 7,13" stroke="#7EC7FF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></polyline>
-        <polyline points="11,5 14,9 11,13" stroke="#7EC7FF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></polyline>
+        <polyline points="7,5 4,9 7,13" stroke="var(--color-primary)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></polyline>
+        <polyline points="11,5 14,9 11,13" stroke="var(--color-primary)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></polyline>
       </svg>
     </div>
 
@@ -90,18 +90,18 @@ const {
       class="pointer-events-none"
       style="position: absolute; bottom: 12px; left: 50%; transform: translateX(-50%); background: rgba(13,13,13,0.85); border: 1px solid #2a2a2a; padding: 4px 12px;"
     >
-      <span class="text-[9px] font-mono uppercase tracking-widest text-[#FAFAFA]/40">drag to compare</span>
+      <span class="text-[9px] font-mono uppercase tracking-widest text-base-content/40">drag to compare</span>
     </div>
   </div>
 
   <div class="flex justify-between mt-3">
     <div class="flex items-center gap-2">
       <div class="w-2 h-2 bg-red-400 opacity-70"></div>
-      <span class="text-[10px] font-mono text-[#FAFAFA]/40 uppercase tracking-widest">{beforeLabel}</span>
+      <span class="text-[10px] font-mono text-base-content/40 uppercase tracking-widest">{beforeLabel}</span>
     </div>
     <div class="flex items-center gap-2">
-      <span class="text-[10px] font-mono text-[#FAFAFA]/40 uppercase tracking-widest">{afterLabel}</span>
-      <div class="w-2 h-2 opacity-70" style="background: #7EC7FF;"></div>
+      <span class="text-[10px] font-mono text-base-content/40 uppercase tracking-widest">{afterLabel}</span>
+      <div class="w-2 h-2 opacity-70 bg-primary"></div>
     </div>
   </div>
 </div>

--- a/src/components/case-study/Callout.astro
+++ b/src/components/case-study/Callout.astro
@@ -16,12 +16,12 @@ type Props = {
 
 const { title, icon: Icon, accent = "teal", class: className = "" } = Astro.props;
 
-const accentColor = accent === "amber" ? "#F4915C" : "#7EC7FF";
+const accentColor = accent === "amber" ? "var(--color-warning)" : "var(--color-primary)";
 ---
 
-<div class={`not-prose border border-white/10 p-4 bg-white/5 ${className}`}>
+<div class={`not-prose border border-base-300 p-4 bg-white/5 ${className}`}>
   <h4
-    class="text-sm uppercase tracking-[0.2em] font-bold mb-3 flex items-center gap-3 text-[#FAFAFA]"
+    class="text-sm uppercase tracking-[0.2em] font-bold mb-3 flex items-center gap-3 text-base-content"
   >
     {Icon && <Icon size={14} color={accentColor} />}
     <span>{title}</span>

--- a/src/components/case-study/CaseStudyContent.astro
+++ b/src/components/case-study/CaseStudyContent.astro
@@ -36,7 +36,7 @@ const relatedEntries = related && related.length > 0 ? await getEntries(related)
 
 <div class="case-study-content space-y-10">
   {media && (
-    <div class="case-study-media border border-white/10 overflow-hidden">
+    <div class="case-study-media border border-base-300 overflow-hidden">
       {media.type === "image" ? (
         <img
           src={media.src}
@@ -60,13 +60,13 @@ const relatedEntries = related && related.length > 0 ? await getEntries(related)
 
   {showHeader && (
     <header class="space-y-4">
-      <h1 class={fullPage ? "text-4xl md:text-5xl font-bold text-[#FAFAFA] leading-tight" : "text-2xl md:text-3xl font-bold text-[#FAFAFA] leading-tight"}>
+      <h1 class={fullPage ? "text-4xl md:text-5xl font-bold text-base-content leading-tight" : "text-2xl md:text-3xl font-bold text-base-content leading-tight"}>
         {title}
       </h1>
       {tags && tags.length > 0 && (
         <div class="flex flex-wrap items-center gap-3">
           {tags.map((tag) => (
-            <span class="px-2 py-0.5 text-[10px] uppercase tracking-widest border border-white/10 text-[#FAFAFA]/60">
+            <span class="badge text-base-content/60">
               {tag}
             </span>
           ))}
@@ -90,8 +90,8 @@ const relatedEntries = related && related.length > 0 ? await getEntries(related)
   )}
 
   {fullPage && relatedEntries.length > 0 && (
-    <section class="space-y-6 border-t border-white/10 pt-10">
-      <span class="text-[10px] uppercase tracking-widest text-[#FAFAFA]/40 block">
+    <section class="space-y-6 border-t border-base-300 pt-10">
+      <span class="text-[10px] uppercase tracking-widest text-base-content/40 block">
         Related reading
       </span>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -101,7 +101,7 @@ const relatedEntries = related && related.length > 0 ? await getEntries(related)
             title={post.data.title}
             date={post.data.date}
             author={post.data.author}
-            titleColor="#F4C45C"
+            titleColor="var(--color-accent)"
             label="Read also"
           />
         ))}

--- a/src/components/case-study/ComponentsReference.astro
+++ b/src/components/case-study/ComponentsReference.astro
@@ -24,10 +24,10 @@ const propsRows = (rows: PropRow[]) => rows;
   <!-- Intro — shared between the page and the in-window versions so both
        open with the same framing. -->
   <header class="space-y-3">
-    <span class="text-[10px] uppercase tracking-[0.2em] text-[#FAFAFA]/60 font-mono">
+    <span class="text-[10px] uppercase tracking-[0.2em] text-base-content/60 font-mono">
       Internal · reference
     </span>
-    <h1 class="text-2xl font-bold tracking-tight text-[#FAFAFA]">
+    <h1 class="text-2xl font-bold tracking-tight text-base-content">
       Case study components
     </h1>
     <p class="text-sm text-body max-w-2xl leading-relaxed">
@@ -40,11 +40,11 @@ const propsRows = (rows: PropRow[]) => rows;
 
   <!-- Stage ------------------------------------------------------------- -->
   <section class="space-y-6">
-    <header class="space-y-3 border-l-2 border-[#C792EA] pl-3">
-      <h3 class="font-mono uppercase tracking-widest text-xs text-[#C792EA]">
+    <header class="space-y-3 border-l-2 border-secondary pl-3">
+      <h3 class="font-mono uppercase tracking-widest text-xs text-secondary">
         Stage
       </h3>
-      <p class="text-sm text-[#FAFAFA]/75 leading-relaxed">
+      <p class="text-sm text-base-content/75 leading-relaxed">
         Section wrapper with a sticky label column. Use to break a case study
         into named beats (Discovery, Build, Outcome…). Children render in the
         right column.
@@ -55,15 +55,15 @@ const propsRows = (rows: PropRow[]) => rows;
           { name: "heading", type: "string", status: "optional" },
         ]).map((p) => (
           <Fragment>
-            <dt class="text-[#FAFAFA]">{p.name}</dt>
-            <dd class="text-[#FAFAFA]/75">
+            <dt class="text-base-content">{p.name}</dt>
+            <dd class="text-base-content/75">
               {p.type}{" "}
-              <span class="text-[#FAFAFA]/45">— {p.status}</span>
+              <span class="text-base-content/45">— {p.status}</span>
             </dd>
           </Fragment>
         ))}
       </dl>
-      <code class="text-xs text-[#FAFAFA]/55 block font-mono pt-1">
+      <code class="text-xs text-base-content/55 block font-mono pt-1">
         import Stage from "@components/case-study/Stage.astro";
       </code>
     </header>
@@ -83,11 +83,11 @@ const propsRows = (rows: PropRow[]) => rows;
 
   <!-- Callout ----------------------------------------------------------- -->
   <section class="space-y-6">
-    <header class="space-y-3 border-l-2 border-[#C792EA] pl-3">
-      <h3 class="font-mono uppercase tracking-widest text-xs text-[#C792EA]">
+    <header class="space-y-3 border-l-2 border-secondary pl-3">
+      <h3 class="font-mono uppercase tracking-widest text-xs text-secondary">
         Callout
       </h3>
-      <p class="text-sm text-[#FAFAFA]/75 leading-relaxed">
+      <p class="text-sm text-base-content/75 leading-relaxed">
         Boxed note with a header and optional icon. Use for technical asides,
         architecture notes, or "why we chose X" interjections within prose.
       </p>
@@ -98,15 +98,15 @@ const propsRows = (rows: PropRow[]) => rows;
           { name: "accent", type: `"teal" | "amber"`, status: `default "teal"` },
         ]).map((p) => (
           <Fragment>
-            <dt class="text-[#FAFAFA]">{p.name}</dt>
-            <dd class="text-[#FAFAFA]/75">
+            <dt class="text-base-content">{p.name}</dt>
+            <dd class="text-base-content/75">
               {p.type}{" "}
-              <span class="text-[#FAFAFA]/45">— {p.status}</span>
+              <span class="text-base-content/45">— {p.status}</span>
             </dd>
           </Fragment>
         ))}
       </dl>
-      <code class="text-xs text-[#FAFAFA]/55 block font-mono pt-1">
+      <code class="text-xs text-base-content/55 block font-mono pt-1">
         import Callout from "@components/case-study/Callout.astro";
         <br />
         import {"{ Database }"} from "@lucide/astro";
@@ -129,17 +129,17 @@ const propsRows = (rows: PropRow[]) => rows;
 
   <!-- InlineNote -------------------------------------------------------- -->
   <section class="space-y-6">
-    <header class="space-y-3 border-l-2 border-[#C792EA] pl-3">
-      <h3 class="font-mono uppercase tracking-widest text-xs text-[#C792EA]">
+    <header class="space-y-3 border-l-2 border-secondary pl-3">
+      <h3 class="font-mono uppercase tracking-widest text-xs text-secondary">
         InlineNote
       </h3>
-      <p class="text-sm text-[#FAFAFA]/75 leading-relaxed">
+      <p class="text-sm text-base-content/75 leading-relaxed">
         Quieter, italic aside with a neutral white left border. Use sparingly —
         for a single sentence of meta-commentary inside a stage. No
         configurable props beyond the slot (kept intentionally simple so
         accented sidebars stay distinct as the Quote component).
       </p>
-      <code class="text-xs text-[#FAFAFA]/55 block font-mono pt-1">
+      <code class="text-xs text-base-content/55 block font-mono pt-1">
         import InlineNote from "@components/case-study/InlineNote.astro";
       </code>
     </header>
@@ -152,11 +152,11 @@ const propsRows = (rows: PropRow[]) => rows;
 
   <!-- Quote ------------------------------------------------------------- -->
   <section class="space-y-6">
-    <header class="space-y-3 border-l-2 border-[#C792EA] pl-3">
-      <h3 class="font-mono uppercase tracking-widest text-xs text-[#C792EA]">
+    <header class="space-y-3 border-l-2 border-secondary pl-3">
+      <h3 class="font-mono uppercase tracking-widest text-xs text-secondary">
         Quote
       </h3>
-      <p class="text-sm text-[#FAFAFA]/75 leading-relaxed">
+      <p class="text-sm text-base-content/75 leading-relaxed">
         Pulled testimonial or framing line. Use sparingly to mark a beat that
         should land.
       </p>
@@ -167,15 +167,15 @@ const propsRows = (rows: PropRow[]) => rows;
           { name: "size", type: `"default" | "large"`, status: `default "default"` },
         ]).map((p) => (
           <Fragment>
-            <dt class="text-[#FAFAFA]">{p.name}</dt>
-            <dd class="text-[#FAFAFA]/75">
+            <dt class="text-base-content">{p.name}</dt>
+            <dd class="text-base-content/75">
               {p.type}{" "}
-              <span class="text-[#FAFAFA]/45">— {p.status}</span>
+              <span class="text-base-content/45">— {p.status}</span>
             </dd>
           </Fragment>
         ))}
       </dl>
-      <code class="text-xs text-[#FAFAFA]/55 block font-mono pt-1">
+      <code class="text-xs text-base-content/55 block font-mono pt-1">
         import Quote from "@components/case-study/Quote.astro";
       </code>
     </header>
@@ -194,11 +194,11 @@ const propsRows = (rows: PropRow[]) => rows;
 
   <!-- StateList --------------------------------------------------------- -->
   <section class="space-y-6">
-    <header class="space-y-3 border-l-2 border-[#C792EA] pl-3">
-      <h3 class="font-mono uppercase tracking-widest text-xs text-[#C792EA]">
+    <header class="space-y-3 border-l-2 border-secondary pl-3">
+      <h3 class="font-mono uppercase tracking-widest text-xs text-secondary">
         StateList
       </h3>
-      <p class="text-sm text-[#FAFAFA]/75 leading-relaxed">
+      <p class="text-sm text-base-content/75 leading-relaxed">
         Titled list of short, bulleted points. Good for "what we considered",
         "constraints", or "what changed".
       </p>
@@ -210,15 +210,15 @@ const propsRows = (rows: PropRow[]) => rows;
           { name: "accent", type: `"teal" | "amber"`, status: `default "amber"` },
         ]).map((p) => (
           <Fragment>
-            <dt class="text-[#FAFAFA]">{p.name}</dt>
-            <dd class="text-[#FAFAFA]/75">
+            <dt class="text-base-content">{p.name}</dt>
+            <dd class="text-base-content/75">
               {p.type}{" "}
-              <span class="text-[#FAFAFA]/45">— {p.status}</span>
+              <span class="text-base-content/45">— {p.status}</span>
             </dd>
           </Fragment>
         ))}
       </dl>
-      <code class="text-xs text-[#FAFAFA]/55 block font-mono pt-1">
+      <code class="text-xs text-base-content/55 block font-mono pt-1">
         import StateList from "@components/case-study/StateList.astro";
       </code>
     </header>
@@ -248,11 +248,11 @@ const propsRows = (rows: PropRow[]) => rows;
 
   <!-- MetricsBar -------------------------------------------------------- -->
   <section class="space-y-6">
-    <header class="space-y-3 border-l-2 border-[#C792EA] pl-3">
-      <h3 class="font-mono uppercase tracking-widest text-xs text-[#C792EA]">
+    <header class="space-y-3 border-l-2 border-secondary pl-3">
+      <h3 class="font-mono uppercase tracking-widest text-xs text-secondary">
         MetricsBar
       </h3>
-      <p class="text-sm text-[#FAFAFA]/75 leading-relaxed">
+      <p class="text-sm text-base-content/75 leading-relaxed">
         Inline strip of headline numbers. Lays out as 1/2/3/4 columns based on
         the length of <code class="font-mono">metrics</code> — the grid responds
         automatically.
@@ -266,15 +266,15 @@ const propsRows = (rows: PropRow[]) => rows;
           },
         ]).map((p) => (
           <Fragment>
-            <dt class="text-[#FAFAFA]">{p.name}</dt>
-            <dd class="text-[#FAFAFA]/75">
+            <dt class="text-base-content">{p.name}</dt>
+            <dd class="text-base-content/75">
               {p.type}{" "}
-              <span class="text-[#FAFAFA]/45">— {p.status}</span>
+              <span class="text-base-content/45">— {p.status}</span>
             </dd>
           </Fragment>
         ))}
       </dl>
-      <code class="text-xs text-[#FAFAFA]/55 block font-mono pt-1">
+      <code class="text-xs text-base-content/55 block font-mono pt-1">
         import MetricsBar from "@components/case-study/MetricsBar.astro";
       </code>
     </header>
@@ -290,11 +290,11 @@ const propsRows = (rows: PropRow[]) => rows;
 
   <!-- OutcomeGrid ------------------------------------------------------- -->
   <section class="space-y-6">
-    <header class="space-y-3 border-l-2 border-[#C792EA] pl-3">
-      <h3 class="font-mono uppercase tracking-widest text-xs text-[#C792EA]">
+    <header class="space-y-3 border-l-2 border-secondary pl-3">
+      <h3 class="font-mono uppercase tracking-widest text-xs text-secondary">
         OutcomeGrid
       </h3>
-      <p class="text-sm text-[#FAFAFA]/75 leading-relaxed">
+      <p class="text-sm text-base-content/75 leading-relaxed">
         Vertical list of outcomes (title + short paragraph) tagged with a
         short ID in a narrow left column. Pairs well after a MetricsBar —
         numbers above, narrative below.
@@ -314,15 +314,15 @@ const propsRows = (rows: PropRow[]) => rows;
           },
         ]).map((p) => (
           <Fragment>
-            <dt class="text-[#FAFAFA]">{p.name}</dt>
-            <dd class="text-[#FAFAFA]/75">
+            <dt class="text-base-content">{p.name}</dt>
+            <dd class="text-base-content/75">
               {p.type}{" "}
-              <span class="text-[#FAFAFA]/45">— {p.status}</span>
+              <span class="text-base-content/45">— {p.status}</span>
             </dd>
           </Fragment>
         ))}
       </dl>
-      <code class="text-xs text-[#FAFAFA]/55 block font-mono pt-1">
+      <code class="text-xs text-base-content/55 block font-mono pt-1">
         import OutcomeGrid from "@components/case-study/OutcomeGrid.astro";
       </code>
     </header>
@@ -369,11 +369,11 @@ const propsRows = (rows: PropRow[]) => rows;
 
   <!-- BeforeAfterSlider ------------------------------------------------- -->
   <section class="space-y-6">
-    <header class="space-y-3 border-l-2 border-[#C792EA] pl-3">
-      <h3 class="font-mono uppercase tracking-widest text-xs text-[#C792EA]">
+    <header class="space-y-3 border-l-2 border-secondary pl-3">
+      <h3 class="font-mono uppercase tracking-widest text-xs text-secondary">
         BeforeAfterSlider
       </h3>
-      <p class="text-sm text-[#FAFAFA]/75 leading-relaxed">
+      <p class="text-sm text-base-content/75 leading-relaxed">
         Draggable comparison between two images (the classic "before / after"
         wipe). Use to show a redesigned interface, a cleaned-up data view, or
         any state change that reads visually. Source images can be passed as
@@ -391,15 +391,15 @@ const propsRows = (rows: PropRow[]) => rows;
           { name: "aspectRatio", type: "string (CSS)", status: `default "16 / 10"` },
         ]).map((p) => (
           <Fragment>
-            <dt class="text-[#FAFAFA]">{p.name}</dt>
-            <dd class="text-[#FAFAFA]/75">
+            <dt class="text-base-content">{p.name}</dt>
+            <dd class="text-base-content/75">
               {p.type}{" "}
-              <span class="text-[#FAFAFA]/45">— {p.status}</span>
+              <span class="text-base-content/45">— {p.status}</span>
             </dd>
           </Fragment>
         ))}
       </dl>
-      <code class="text-xs text-[#FAFAFA]/55 block font-mono pt-1">
+      <code class="text-xs text-base-content/55 block font-mono pt-1">
         import BeforeAfterSlider from "@components/case-study/BeforeAfterSlider.astro";
       </code>
     </header>

--- a/src/components/case-study/InlineNote.astro
+++ b/src/components/case-study/InlineNote.astro
@@ -9,8 +9,8 @@ type Props = {
 const { class: className = "" } = Astro.props;
 ---
 
-<div class={`not-prose p-4 bg-white/5 border-l-2 border-white/25 ${className}`}>
-  <p class="text-sm italic text-[#FAFAFA] leading-relaxed max-w-2xl">
+<div class={`not-prose p-4 bg-white/5 border-l-2 border-base-content/25 ${className}`}>
+  <p class="text-sm italic text-base-content leading-relaxed max-w-2xl">
     <slot />
   </p>
 </div>

--- a/src/components/case-study/MetricsBar.astro
+++ b/src/components/case-study/MetricsBar.astro
@@ -17,12 +17,12 @@ const cols =
 ---
 
 {metrics.length > 0 && (
-  <section class={`grid grid-cols-1 ${cols} border border-white/10 bg-white/5 ${className}`}>
+  <section class={`grid grid-cols-1 ${cols} border border-base-300 bg-white/5 ${className}`}>
     {metrics.map((metric, idx) => (
       <div
-        class={`p-6 ${idx !== metrics.length - 1 ? "md:border-r border-b md:border-b-0 border-white/10" : ""}`}
+        class={`p-6 ${idx !== metrics.length - 1 ? "md:border-r border-b md:border-b-0 border-base-300" : ""}`}
       >
-        <div class="text-3xl font-bold mb-4 text-[#FAFAFA]">{metric.value}</div>
+        <div class="text-3xl font-bold mb-4 text-base-content">{metric.value}</div>
         <div class="text-sm text-white/60">
           {metric.label}
         </div>

--- a/src/components/case-study/OutcomeGrid.astro
+++ b/src/components/case-study/OutcomeGrid.astro
@@ -28,11 +28,11 @@ const labelFor = (i: number) =>
 {outcomes.length > 0 && (
   <section
     data-outcomes
-    class={`not-prose grid grid-cols-1 md:grid-cols-[1fr_5fr] gap-3 md:gap-6 border-t border-white/10 pt-6 ${className}`}
+    class={`not-prose grid grid-cols-1 md:grid-cols-[1fr_5fr] gap-3 md:gap-6 border-t border-base-300 pt-6 ${className}`}
   >
     <div>
       <div class="outcomes-label-sticky md:sticky">
-        <span class="text-xs uppercase tracking-widest text-[#FAFAFA]/80 block pt-5">
+        <span class="text-xs uppercase tracking-widest text-base-content/80 block pt-5">
           Outcomes
         </span>
       </div>
@@ -40,18 +40,18 @@ const labelFor = (i: number) =>
 
     <div class="space-y-6">
       {heading && (
-        <h2 class="!mt-0 text-2xl md:text-3xl font-bold leading-tight text-[#FAFAFA]">
+        <h2 class="!mt-0 text-2xl md:text-3xl font-bold leading-tight text-base-content">
           {heading}
         </h2>
       )}
-      <ul class="list-none p-0 m-0 divide-y divide-white/10 border-b border-white/10">
+      <ul class="list-none p-0 m-0 divide-y divide-base-300 border-b border-base-300">
         {outcomes.map((outcome, idx) => (
           <li class="grid grid-cols-[3rem_1fr] gap-6 py-4">
-            <span class="font-mono text-xs uppercase tracking-widest text-[#FAFAFA]/60 pt-0.5">
+            <span class="font-mono text-xs uppercase tracking-widest text-base-content/60 pt-0.5">
               {labelFor(idx)}
             </span>
             <div>
-              <h4 class="text-[#FAFAFA] text-sm font-bold mb-2">
+              <h4 class="text-base-content text-sm font-bold mb-2">
                 {outcome.title}
               </h4>
               <p class="text-body text-sm leading-relaxed">

--- a/src/components/case-study/Quote.astro
+++ b/src/components/case-study/Quote.astro
@@ -13,19 +13,19 @@ const {
   class: className = "",
 } = Astro.props;
 
-const borderColor = accent === "amber" ? "#F4915C" : "#7EC7FF";
+const borderColor = accent === "amber" ? "var(--color-warning)" : "var(--color-primary)";
 const textSize = size === "large" ? "text-2xl md:text-4xl" : "text-xl md:text-2xl";
 ---
 
 <div
-  class={`bg-white/5 border-y border-r border-white/10 border-l-2 p-4 md:p-8 ${className}`}
+  class={`bg-white/5 border-y border-r border-base-300 border-l-2 p-4 md:p-8 ${className}`}
   style={`border-left-color: ${borderColor};`}
 >
-  <blockquote class={`${textSize} italic leading-tight mb-3 text-[#FAFAFA]`}>
+  <blockquote class={`${textSize} italic leading-tight mb-3 text-base-content`}>
     <slot />
   </blockquote>
   {attribution && (
-    <cite class="text-sm text-[#FAFAFA]/80 not-italic">
+    <cite class="text-sm text-base-content/80 not-italic">
       — {attribution}
     </cite>
   )}

--- a/src/components/case-study/Stage.astro
+++ b/src/components/case-study/Stage.astro
@@ -21,14 +21,14 @@ const slug = id ?? label.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-
 >
   <div>
     <div class="stage-label-sticky md:sticky">
-      <span class="text-xs uppercase tracking-widest text-[#FAFAFA]/80 block pt-2">
+      <span class="text-xs uppercase tracking-widest text-base-content/80 block pt-2">
         {label}
       </span>
     </div>
   </div>
   <div class="space-y-6">
     {heading && (
-      <h2 class="!mt-0 text-2xl md:text-3xl font-bold leading-tight text-[#FAFAFA]">
+      <h2 class="!mt-0 text-2xl md:text-3xl font-bold leading-tight text-base-content">
         {heading}
       </h2>
     )}

--- a/src/components/case-study/StateList.astro
+++ b/src/components/case-study/StateList.astro
@@ -22,10 +22,10 @@ const {
   class: className = "",
 } = Astro.props;
 
-const accentColor = accent === "amber" ? "#F4915C" : "#7EC7FF";
+const accentColor = accent === "amber" ? "var(--color-warning)" : "var(--color-primary)";
 ---
 
-<div class={`not-prose bg-white/5 border border-white/10 p-4 ${className}`}>
+<div class={`not-prose bg-white/5 border border-base-300 p-4 ${className}`}>
   <h4
     class="text-base font-bold mb-3 flex items-center gap-2"
     style={`color: ${accentColor};`}

--- a/src/components/case-study/TerminalWindow.astro
+++ b/src/components/case-study/TerminalWindow.astro
@@ -65,7 +65,7 @@ const {
     box-shadow:
       0 0 0 2px #1a1a1a,
       0 0 0 4px ${accent},
-      0 0 0 6px #0a0a0a,
+      0 0 0 6px hsl(var(--b1)),
       0 0 0 8px #1a1a1a,
       4px 4px 0 8px rgba(0,0,0,0.8),
       8px 8px 0 8px rgba(0,0,0,0.4);
@@ -83,7 +83,7 @@ const {
   <header
     data-window-titlebar
     class="terminal-titlebar flex items-center justify-between gap-2 px-1.5 py-1.5 cursor-grab select-none"
-    style={`background: #0a0a0a; border-bottom: 2px solid ${accent};`}
+    style={`background: hsl(var(--b1)); border-bottom: 2px solid ${accent};`}
   >
     <div class="flex items-center gap-2 min-w-0">
       <Terminal size={14} color={accent} />
@@ -147,7 +147,7 @@ const {
       )}
 
       {title && (
-        <div class="mb-4 pb-3 border-b border-white/10">
+        <div class="mb-4 pb-3 border-b border-base-300">
           <span
             class="font-mono font-bold uppercase tracking-[0.05em] text-[13px]"
             style={`color: ${accent};`}
@@ -164,7 +164,7 @@ const {
       <!-- End-of-content marker. Standard chrome for every window — signals
            you've reached the bottom and reminds how to close. -->
       <div
-        class="not-prose mt-12 pt-6 border-white/10 flex justify-start items-start gap-2 font-mono text-[10px] uppercase tracking-widest text-[#FAFAFA]/45"
+        class="not-prose mt-12 pt-6 border-base-300 flex justify-start items-start gap-2 font-mono text-[10px] uppercase tracking-widest text-base-content/45"
       >
         <KbdChip keys="Esc" text />
         <span>to close this window</span>
@@ -177,7 +177,7 @@ const {
 <style>
   .terminal-window {
     transform-origin: top left;
-    background: #0A0A0A;
+    background: hsl(var(--b1));
   }
 
   /* Open animation — mirrors the framer-motion spring (stiffness 320, damping 26)
@@ -262,8 +262,8 @@ const {
 
   /* Body palette — site colors with mono font */
   .terminal-body {
-    background: #0A0A0A;
-    color: #FAFAFA;
+    background: hsl(var(--b1));
+    color: hsl(var(--bc));
     font-family: "JetBrains Mono", "Courier New", Courier, monospace;
     line-height: 1.65;
   }

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -19,7 +19,7 @@ const { title, description, breadcrumb, noindex = false } = Astro.props;
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="codemyriad">
   <head>
     <Head title={`${title} | ${SITE.NAME}`} description={description} noindex={noindex} />
   </head>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -44,15 +44,15 @@ const relatedPosts = (post.data.relatedPosts ?? [])
     </div>
     <div class="space-y-3 my-10">
       <div class="animate flex items-center gap-1.5">
-        <div class="font-base text-sm text-[#7ec7ff]">
+        <div class="font-base text-sm text-primary">
           <FormattedDate date={post.data.date} />
         </div>
         &bull;
-        <div class="font-base text-sm text-[#7ec7ff]">
+        <div class="font-base text-sm text-primary">
           {readingTime(post.body)}
         </div>
         &bull;
-        <div class="font-base text-sm text-[#7ec7ff]">
+        <div class="font-base text-sm text-primary">
           {post.data.author}
         </div>
       </div>
@@ -65,8 +65,8 @@ const relatedPosts = (post.data.relatedPosts ?? [])
     </article>
     {relatedPosts.length > 0 && (
       <div class="mt-16 space-y-6">
-        <div class="border-t border-white/10 pt-4">
-          <h2 data-typeout class="text-base font-medium text-[#FAFAFA]/40">/ Related reading</h2>
+        <div class="border-t border-base-300 pt-4">
+          <h2 data-typeout class="text-base font-medium text-base-content/40">/ Related reading</h2>
         </div>
         <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {relatedPosts.map((related) => (
@@ -75,7 +75,7 @@ const relatedPosts = (post.data.relatedPosts ?? [])
               title={related.data.title}
               date={related.data.date}
               author={related.data.author}
-              titleColor="#FAFAFA"
+              titleColor="var(--color-base-content)"
             />
           ))}
         </div>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -28,7 +28,7 @@ const posts = (await getCollection("blog"))
               title={post.data.title}
               date={post.data.date}
               author={post.data.author}
-              titleColor="#FAFAFA"
+              titleColor="var(--color-base-content)"
             />
           ))
         }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,7 @@ import BlogCard from "@components/BlogCard.astro";
 import ContactSection from "@components/ContactSection.astro";
 import ServicesTabs from "@components/ServicesTabs.astro";
 // import { dateRange } from "@lib/utils";
+import { ArrowRight } from "@lucide/astro";
 import {
   HOME,
   //LINKS
@@ -54,17 +55,17 @@ const formatCounts = (c: { work: number; experiments: number }) => {
   return parts.join(" · ");
 };
 
-const blogTitleColors = ["#F4C45C", "#F4915C"];
+const blogTitleColors = ["var(--color-accent)", "var(--color-warning)"];
 ---
 
 <PageLayout title={HOME.TITLE} description={HOME.DESCRIPTION}>
   <Container>
     <div class="space-y-20 max-w-screen-lg mx-auto">
       <section id="hero" class="space-y-3">
-        <h1 class="text-4xl font-bold leading-tight text-[#FAFAFA]">
+        <h1 class="text-4xl font-bold leading-tight text-base-content">
           Operational systems for growing companies.
         </h1>
-        <p class="text-lg text-[#7EC7FF]">
+        <p class="text-lg text-primary">
           We build the connective tissue between tools, teams, and workflows.
         </p>
       </section>
@@ -76,9 +77,9 @@ const blogTitleColors = ["#F4C45C", "#F4915C"];
       <section id="projects" class="space-y-6">
         <div class="grid sm:grid-cols-2 md:grid-cols-3">
           <div
-            class="flex min-h-[170px] flex-col justify-between border border-white/10 p-6"
+            class="flex min-h-[170px] flex-col justify-between border border-base-300 p-6"
           >
-            <h2 class="text-xl font-medium text-[#FAFAFA]/50">Projects</h2>
+            <h2 class="text-xl font-medium text-base-content/50">Projects</h2>
           </div>
           {
             projects.map((project) => {
@@ -87,43 +88,34 @@ const blogTitleColors = ["#F4C45C", "#F4915C"];
               return (
               <a
                 href={`/${project.collection}/${project.slug}`}
-                class="group flex min-h-[170px] flex-col justify-between border border-white/10 bg-white/5 p-6 transition-colors duration-300 hover:bg-white/10"
+                class="group flex min-h-[170px] flex-col justify-between border border-base-300 bg-white/5 p-6 transition-colors duration-300 hover:bg-white/10"
               >
                 <div class="space-y-3">
-                  <h3 class="text-xl font-medium text-[#FAFAFA]">
+                  <h3 class="text-xl font-medium text-base-content">
                     {project.data.client ?? project.data.title}
                   </h3>
-                  <p class="text-base text-[#FAFAFA]/60">
+                  <p class="text-base text-base-content/60">
                     {project.data.description}
                   </p>
                   {counts.total > 0 && (
-                    <div class="flex items-center gap-2 text-[11px] font-mono uppercase tracking-widest text-[#FAFAFA]/50">
+                    <div class="flex items-center gap-2 text-[11px] font-mono uppercase tracking-widest text-base-content/50">
                       <span class="relative w-2 h-2 inline-block">
                         <span
                           class="absolute inset-0 rounded-full animate-ping opacity-60"
-                          style="background: #7EC7FF;"
+                          style="background: var(--color-primary);"
                         />
                         <span
                           class="relative block w-2 h-2 rounded-full"
-                          style="background: #7EC7FF;"
+                          style="background: var(--color-primary);"
                         />
                       </span>
                       <span>{countsLabel}</span>
                     </div>
                   )}
                 </div>
-                <div class="mt-6 flex items-center justify-end text-[#FAFAFA]/60 transition-colors duration-300 group-hover:text-[#FAFAFA]">
-                  <span class="inline-flex size-8 items-center justify-center rounded-md border border-white/10 bg-white/5">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 24 24"
-                      class="size-4 stroke-2"
-                      fill="none"
-                      stroke="currentColor"
-                    >
-                      <line x1="5" y1="12" x2="19" y2="12" />
-                      <polyline points="12 5 19 12 12 19" />
-                    </svg>
+                <div class="mt-6 flex items-center justify-end">
+                  <span class="inline-flex size-8 shrink-0 items-center justify-center border border-base-300 text-base-content transition-colors group-hover:border-base-content/40">
+                    <ArrowRight size={14} />
                   </span>
                 </div>
               </a>
@@ -136,10 +128,10 @@ const blogTitleColors = ["#F4C45C", "#F4915C"];
       <section id="blog" class="space-y-6">
         <div class="grid sm:grid-cols-2 md:grid-cols-3">
           <div
-            class="flex min-h-[170px] flex-col justify-between border border-white/10 p-6"
+            class="flex min-h-[170px] flex-col justify-between border border-base-300 p-6"
           >
-            <h2 class="text-xl font-medium text-[#FAFAFA]/50">Blog</h2>
-            <a href="/blog" class="group inline-flex items-center gap-2 text-sm text-[#FAFAFA]/40 hover:text-[#FAFAFA] transition-colors duration-300">
+            <h2 class="text-xl font-medium text-base-content/50">Blog</h2>
+            <a href="/blog" class="group inline-flex items-center gap-2 text-sm text-base-content/40 hover:text-base-content transition-colors duration-300">
               View all
               <svg
                 xmlns="http://www.w3.org/2000/svg"

--- a/src/pages/projects/[project].astro
+++ b/src/pages/projects/[project].astro
@@ -108,7 +108,7 @@ clickableStudies.forEach((cs, idx) => {
       <section class="grid grid-cols-1 md:grid-cols-[3fr_2fr] gap-10 md:gap-12 items-start">
         <div class="space-y-6">
           <div class="space-y-3">
-            <h1 class="text-4xl md:text-5xl font-bold tracking-tight text-[#FAFAFA]">
+            <h1 class="text-4xl md:text-5xl font-bold tracking-tight text-base-content">
               {client}
             </h1>
           </div>
@@ -120,16 +120,16 @@ clickableStudies.forEach((cs, idx) => {
         </div>
 
         {META_ROWS.length > 0 && (
-          <aside class="border border-white/10 divide-y divide-white/10 self-start">
+          <aside class="border border-base-300 divide-y divide-base-300 self-start">
             {META_ROWS.map((row) => (
               <div class="flex justify-between items-start px-4 py-3 gap-4">
-                <span class="text-[10px] uppercase tracking-widest text-[#FAFAFA]/40 shrink-0 pt-0.5">
+                <span class="text-[10px] uppercase tracking-widest text-base-content/40 shrink-0 pt-0.5">
                   {row.label}
                 </span>
                 {Array.isArray(row.value) ? (
                   <div class="flex flex-wrap gap-1.5 justify-end">
                     {row.value.map((tag) => (
-                      <span class="px-2 py-0.5 text-[10px] uppercase tracking-widest border border-white/10 text-[#FAFAFA]/60">
+                      <span class="badge text-base-content/60">
                         {tag}
                       </span>
                     ))}
@@ -139,7 +139,7 @@ clickableStudies.forEach((cs, idx) => {
                     href={row.href}
                     target="_blank"
                     rel="noreferrer"
-                    class="text-xs text-[#7EC7FF] hover:text-[#7EC7FF]/80 truncate text-right"
+                    class="text-xs text-primary underline-offset-2 truncate text-right hover:underline hover:decoration-primary"
                   >
                     {row.value.replace(/^https?:\/\//, "")}
                   </a>
@@ -155,17 +155,17 @@ clickableStudies.forEach((cs, idx) => {
       {sortedStudies.length > 0 && (
         <section>
           <div class="flex items-center justify-between mb-6">
-            <span class="text-xs uppercase tracking-[0.2em] text-[#FAFAFA]/40">Case Studies</span>
+            <span class="text-xs uppercase tracking-[0.2em] text-base-content/40">Case Studies</span>
           </div>
           <ul class="list-none p-0">
             {sortedStudies.map((cs) => {
               const slug = studySlug(cs);
-              const accent = cs.data.type === "experiment" ? "#F4915C" : "#7EC7FF";
+              const accent = cs.data.type === "experiment" ? "var(--color-warning)" : "var(--color-primary)";
               const canonical = `/projects/${projectSlug}/${slug}`;
               const interactive = cs.data.writeUp !== false;
               return (
                 <li
-                  class={`case-study-card group relative flex items-start w-full border border-white/10 bg-white/5 transition duration-180 ease-in-out mb-4 overflow-clip ${interactive ? "hover:bg-white/10" : ""}`}
+                  class={`case-study-card group relative flex items-start w-full border border-base-300 bg-white/5 transition duration-180 ease-in-out mb-4 overflow-clip ${interactive ? "hover:bg-white/10" : ""}`}
                 >
                   {cs.data.writeUp !== false ? (
                     <a
@@ -184,13 +184,13 @@ clickableStudies.forEach((cs, idx) => {
                       <div class="flex-grow space-y-3 min-w-0">
                         <div class="flex flex-wrap items-center gap-3">
                           <h3
-                            class="text-lg font-bold text-[#FAFAFA]"
+                            class="text-lg font-bold text-base-content"
                             style={`text-decoration-color: ${accent};`}
                           >
                             {cs.data.title}
                           </h3>
                           {cs.data.tags && cs.data.tags.length > 0 && cs.data.tags.map((tag: string) => (
-                            <span class="px-2 py-0.5 text-[10px] uppercase tracking-widest border border-white/10 text-[#FAFAFA]/60">
+                            <span class="badge text-base-content/60">
                               {tag}
                             </span>
                           ))}
@@ -228,9 +228,9 @@ clickableStudies.forEach((cs, idx) => {
                       <!-- Title + description -->
                       <div class="flex-grow space-y-3 min-w-0">
                         <div class="flex flex-wrap items-center gap-3">
-                          <h3 class="text-lg font-bold text-[#FAFAFA]">{cs.data.title}</h3>
+                          <h3 class="text-lg font-bold text-base-content">{cs.data.title}</h3>
                           {cs.data.tags && cs.data.tags.length > 0 && cs.data.tags.map((tag: string) => (
-                            <span class="px-2 py-0.5 text-[10px] uppercase tracking-widest border border-white/10 text-[#FAFAFA]/60">
+                            <span class="badge text-base-content/60">
                               {tag}
                             </span>
                           ))}
@@ -243,7 +243,7 @@ clickableStudies.forEach((cs, idx) => {
                       <!-- Non-clickable status note (no pulsing dot — this
                            card isn't "live" yet). -->
                       <div class="shrink-0 pt-1 md:text-right">
-                        <span class="text-xs text-[#FAFAFA]/40 italic">
+                        <span class="text-xs text-base-content/40 italic">
                           {cs.data.ctaLabel ?? "In progress"}
                         </span>
                       </div>
@@ -269,7 +269,7 @@ clickableStudies.forEach((cs, idx) => {
     .map((cs) => {
       const slug = studySlug(cs);
       const studyWindowSlug = cs.slug.split("/").slice(-1)[0];
-      const accent = cs.data.type === "experiment" ? "#F4915C" : "#7EC7FF";
+      const accent = cs.data.type === "experiment" ? "var(--color-warning)" : "var(--color-primary)";
       const accentDim = cs.data.type === "experiment" ? "#5a3a22" : "#2a4a6a";
       const filename = `${studyWindowSlug.replace(/-/g, "_")}.log`;
       const statusLabel =
@@ -298,7 +298,7 @@ clickableStudies.forEach((cs, idx) => {
        real thing during refinement. -->
   <TerminalWindow
     slug="components-reference"
-    accent="#C792EA"
+    accent="var(--color-secondary)"
     accentDim="#4a2e6a"
     filename="components_reference.log"
     popoutHref="/lab/case-study-components"

--- a/src/pages/projects/[project]/[caseStudy].astro
+++ b/src/pages/projects/[project]/[caseStudy].astro
@@ -44,10 +44,10 @@ const clientName = parentProject?.data.client ?? parentProject?.data.title ?? pr
     <div class="space-y-12 max-w-screen-lg mx-auto">
       <CaseStudyContent entry={entry} showHeader={true} fullPage={true} />
 
-      <nav class="border-t border-white/10 pt-8">
+      <nav class="border-t border-base-300 pt-8">
         <a
           href={`/projects/${projectSlug}`}
-          class="text-sm text-[#7EC7FF] hover:text-[#7EC7FF]/80 inline-flex items-center gap-2"
+          class="text-sm text-primary hover:text-primary/80 inline-flex items-center gap-2"
         >
           ← Back to {clientName}
         </a>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -4,6 +4,7 @@ import PageLayout from "@layouts/PageLayout.astro";
 import Container from "@components/Container.astro";
 import KbdChip from "@components/KbdChip.astro";
 import { PROJECTS } from "@consts";
+import { ArrowRight } from "@lucide/astro";
 
 const projects = (await getCollection("projects"))
   .filter((project) => !project.data.draft)
@@ -72,7 +73,7 @@ for (const project of projects) {
   <Container>
     <div class="page-fade-in space-y-10 max-w-screen-xl mx-auto">
       <header class="space-y-3">
-        <p class="text-base text-[#FAFAFA]/60">
+        <p class="text-base text-base-content/60">
           A selection of client work and personal projects.
         </p>
       </header>
@@ -88,7 +89,7 @@ for (const project of projects) {
               <li>
                 <a
                   href={`/projects/${project.slug}`}
-                  class="project-card group relative overflow-hidden flex h-72 flex-col justify-between border border-white/10 bg-white/5 p-6 transition-colors duration-300 hover:bg-white/10"
+                  class="project-card group relative overflow-hidden flex h-72 flex-col justify-between border border-base-300 bg-white/5 p-6 transition-colors duration-300 hover:bg-white/10"
                 >
                   {shortcut && (
                     <KbdChip
@@ -97,24 +98,24 @@ for (const project of projects) {
                     />
                   )}
                   <div class="relative z-10 space-y-3 pr-16">
-                    <h2 class="text-2xl font-semibold text-[#FAFAFA]">
+                    <h2 class="text-2xl font-semibold text-base-content">
                       {project.data.client ?? project.data.title}
                     </h2>
                     {project.data.tagline && (
-                      <p class="text-sm text-[#7EC7FF]/80">
+                      <p class="text-sm text-primary/80">
                         {project.data.tagline}
                       </p>
                     )}
                     {counts.total > 0 && (
-                      <div class="flex items-center gap-2 text-[11px] font-mono uppercase tracking-widest text-[#FAFAFA]/50">
+                      <div class="flex items-center gap-2 text-[11px] font-mono uppercase tracking-widest text-base-content/50">
                         <span class="relative w-2 h-2 inline-block">
                           <span
                             class="absolute inset-0 rounded-full animate-ping opacity-60"
-                            style="background: #7EC7FF;"
+                            style="background: var(--color-primary);"
                           />
                           <span
                             class="relative block w-2 h-2 rounded-full"
-                            style="background: #7EC7FF;"
+                            style="background: var(--color-primary);"
                           />
                         </span>
                         <span>{countsLabel}</span>
@@ -124,22 +125,13 @@ for (const project of projects) {
                   <div class="relative z-10 mt-6 flex items-end justify-between gap-4">
                     <div class="flex flex-wrap gap-1.5">
                       {tags.slice(0, 3).map((tag: string) => (
-                        <span class="px-2 py-0.5 text-[10px] uppercase tracking-widest border border-white/10 text-[#FAFAFA]/50">
+                        <span class="badge text-base-content/50">
                           {tag}
                         </span>
                       ))}
                     </div>
-                    <span class="inline-flex size-8 items-center justify-center border border-white/10 bg-white/5 shrink-0 text-[#FAFAFA]/60 group-hover:text-[#FAFAFA] transition-colors">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 24 24"
-                        class="size-4 stroke-2"
-                        fill="none"
-                        stroke="currentColor"
-                      >
-                        <line x1="5" y1="12" x2="19" y2="12" />
-                        <polyline points="12 5 19 12 12 19" />
-                      </svg>
+                    <span class="inline-flex size-8 shrink-0 items-center justify-center border border-base-300 text-base-content transition-colors group-hover:border-base-content/40">
+                      <ArrowRight size={14} />
                     </span>
                   </div>
                 </a>

--- a/src/pages/services/internal-tools.astro
+++ b/src/pages/services/internal-tools.astro
@@ -25,16 +25,16 @@ const getPost = (slug: string) => blogMap[slug];
 
       <!-- Page header -->
       <section class="space-y-3">
-        <h1 data-typeout class="text-6xl font-bold leading-tight text-[#FAFAFA]">
+        <h1 data-typeout class="text-6xl font-bold leading-tight text-base-content">
           Internal Tools
         </h1>
-        <p data-typeout class="text-base text-[#7EC7FF]">Automation · Reporting · Client Portals · Dashboards</p>
+        <p data-typeout class="text-base text-primary">Automation · Reporting · Client Portals · Dashboards</p>
       </section>
 
       <!-- Problem statement -->
       <section data-fade class="grid gap-x-12 md:grid-cols-6">
         <div class="space-y-5 md:col-span-4">
-          <h2 class="text-2xl font-medium leading-snug text-[#FAFAFA]">
+          <h2 class="text-2xl font-medium leading-snug text-base-content">
             Are the spreadsheets that built your business starting to slow you down?
           </h2>
           <p class="text-base leading-relaxed text-body">
@@ -48,7 +48,7 @@ const getPost = (slug: string) => blogMap[slug];
 
       <!-- Workflow Automation -->
       <section data-fade class="space-y-6">
-        <h3 class="text-2xl font-medium text-[#FAFAFA]">Workflow Automation</h3>
+        <h3 class="text-2xl font-medium text-base-content">Workflow Automation</h3>
         <div class="grid gap-x-12 gap-y-8 items-start md:grid-cols-6">
           <div class="space-y-5 md:col-span-4">
             <p class="text-base leading-relaxed text-body">
@@ -69,7 +69,7 @@ const getPost = (slug: string) => blogMap[slug];
                   title={getPost("manual-process-cost")!.data.title}
                   date={getPost("manual-process-cost")!.data.date}
                   author={getPost("manual-process-cost")!.data.author}
-                  titleColor="#F4C45C"
+                  titleColor="var(--color-accent)"
                   label="Read also"
                 />
               </div>
@@ -80,7 +80,7 @@ const getPost = (slug: string) => blogMap[slug];
 
       <!-- Owned Tools -->
       <section data-fade class="space-y-6">
-        <h3 class="text-2xl font-medium text-[#FAFAFA]">Owned Tools</h3>
+        <h3 class="text-2xl font-medium text-base-content">Owned Tools</h3>
         <div class="grid gap-x-12 gap-y-8 items-start md:grid-cols-6">
           <div class="space-y-5 md:col-span-4">
             <p class="text-base leading-relaxed text-body">
@@ -101,7 +101,7 @@ const getPost = (slug: string) => blogMap[slug];
                   title={getPost("saas-subscription-worth-it")!.data.title}
                   date={getPost("saas-subscription-worth-it")!.data.date}
                   author={getPost("saas-subscription-worth-it")!.data.author}
-                  titleColor="#F4915C"
+                  titleColor="var(--color-warning)"
                   label="Read also"
                 />
               </div>
@@ -112,16 +112,16 @@ const getPost = (slug: string) => blogMap[slug];
 
       <!-- Case Studies -->
       <section class="space-y-16">
-        <div class="border-t border-white/10 pt-4">
-        <h1 data-typeout class="text-base font-medium text-[#FAFAFA]/40">/ Case Studies</h1>
+        <div class="border-t border-base-300 pt-4">
+        <h1 data-typeout class="text-base font-medium text-base-content/40">/ Case Studies</h1>
         </div>
 
         <!-- Case study 1: Sales Demo Tool — no blog card -->
         <div data-fade class="space-y-6 pb-4">
           <div class="flex flex-col items-baseline gap-1.5">
-            <h3 class="text-3xl font-medium text-[#FAFAFA]">Sales Demo Tool</h3>
+            <h3 class="text-3xl font-medium text-base-content">Sales Demo Tool</h3>
             <span class="text-base text-body/40">
-              Client / <a href="https://whatisedible.com/" target="blank" class="text-[#7EC7FF] hover:text-[#7EC7FF]/80">Edible</a>
+              Client / <a href="https://whatisedible.com/" target="blank" class="text-primary underline-offset-2 hover:underline hover:decoration-primary">Edible</a>
             </span>
           </div>
           <VideoPlayer src="/videos/sales-tool-demo.webm" />
@@ -146,9 +146,9 @@ const getPost = (slug: string) => blogMap[slug];
         <!-- Case study 2: Property Rental Reports / Aire Spaces — with blog card -->
         <div data-fade class="space-y-6">
           <div class="flex flex-col items-baseline gap-1.5">
-            <h3 class="text-3xl font-medium text-[#FAFAFA]">Property Rental Reports</h3>
+            <h3 class="text-3xl font-medium text-base-content">Property Rental Reports</h3>
             <span class="text-base text-body/40">
-              Client / <a href="https://airespaces.co.uk/" target="blank" class="text-[#7EC7FF] hover:text-[#7EC7FF]/80">Aire Spaces</a>
+              Client / <a href="https://airespaces.co.uk/" target="blank" class="text-primary underline-offset-2 hover:underline hover:decoration-primary">Aire Spaces</a>
             </span>
           </div>
           <VideoPlayer src="/videos/property-report.webm" />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -25,7 +25,7 @@ body {
 body {
   @apply font-sans antialiased;
   @apply flex flex-col;
-  @apply bg-[#0A0A0A] text-[#FAFAFA]/75;
+  @apply bg-base-100 text-base-content/75;
 }
 
 body > header {
@@ -39,7 +39,7 @@ body > header {
 .site-nav-backdrop {
   @apply fixed top-0 left-0 right-0 z-40 pointer-events-none;
   height: var(--site-nav-height, 4.5rem);
-  @apply bg-[#0A0A0A]/70;
+  @apply bg-base-100/70;
   @apply backdrop-blur-md saturate-200;
 }
 
@@ -66,24 +66,64 @@ footer {
 article {
   @apply max-w-full prose prose-invert prose-img:mx-auto prose-img:my-auto;
   @apply prose-headings:font-semibold;
-  @apply prose-headings:text-[#FAFAFA];
-  @apply prose-hr:border-white/10;
+  @apply prose-headings:text-base-content;
+  @apply prose-hr:border-base-300;
+}
+
+@layer components {
+  .caps-sm {
+    @apply font-mono text-sm uppercase tracking-[0.2em] text-base-content/60;
+  }
+
+  .caps-xs {
+    @apply font-mono text-xs uppercase tracking-widest text-base-content/60;
+  }
+
+  .badge {
+    font-size: 0.625rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    padding-left: 4px;
+    padding-right: 4px;
+    background-color: hsl(var(--b2));
+    border-color: hsl(var(--b3));
+  }
 }
 
 @layer utilities {
   .text-body {
-    color: rgb(250 250 250 / 0.75);
+    color: hsl(var(--bc) / 0.75);
   }
 
   article a {
-    @apply font-sans text-[#7ec7ff] underline underline-offset-2;
-    @apply decoration-[#7ec7ff]/50;
+    @apply font-sans text-primary underline-offset-2;
     @apply transition-colors duration-300 ease-in-out;
   }
   article a:hover {
-    @apply text-[#7ec7ff];
-    @apply decoration-[#7ec7ff];
+    @apply underline text-primary decoration-primary;
   }
+}
+
+:focus-visible {
+  outline: 2px solid hsl(var(--bc));
+  outline-offset: 2px;
+}
+
+/* CSS var aliases for inline styles (e.g. proposals) — DaisyUI v3 uses
+   abbreviated var names; these provide readable aliases. */
+[data-theme="codemyriad"] {
+  --color-primary:      hsl(var(--p));
+  --color-secondary:    hsl(var(--s));
+  --color-accent:       hsl(var(--a));
+  --color-neutral:      hsl(var(--n));
+  --color-base-100:     hsl(var(--b1));
+  --color-base-200:     hsl(var(--b2));
+  --color-base-300:     hsl(var(--b3));
+  --color-base-content: hsl(var(--bc));
+  --color-info:         hsl(var(--in));
+  --color-success:      hsl(var(--su));
+  --color-warning:      hsl(var(--wa));
+  --color-error:        hsl(var(--er));
 }
 
 .animate {

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,4 +1,4 @@
-import defaultTheme from "tailwindcss/defaultTheme";
+import { codemyriad, fontFamily } from "./design/theme.mjs";
 
 /** @type {import('tailwindcss').Config} */
 export default {
@@ -8,10 +8,12 @@ export default {
   ],
   theme: {
     extend: {
-      fontFamily: {
-        sans: ["JetBrains Mono", ...defaultTheme.fontFamily.mono],
-      },
+      fontFamily,
     },
   },
-  plugins: [require("@tailwindcss/typography")],
+  plugins: [require("@tailwindcss/typography"), require("daisyui")],
+  daisyui: {
+    themes: [{ codemyriad }],
+    logs: false,
+  },
 };


### PR DESCRIPTION
Adopts a shared brand design layer and migrates the site onto design tokens (Alex's `D-387` work, routed here from the private proposals fork).

## What this does
- **Shared brand layer** — `design/theme.mjs` (the DaisyUI `codemyriad` theme + JetBrains Mono) is the single source of truth, imported by `tailwind.config.mjs`. The private `codemyriad/proposals` repo vendors a **byte-identical** copy and drift-checks against this repo.
- **Tokenises the site** — components/pages now use DaisyUI tokens (`bg-base-100`, `text-primary`, `.btn`, `.badge`, …) instead of hardcoded hex.
- **Docs** — new `DESIGN.md` (the design system) + `CLAUDE.md` (agent guide) + README pointer.

## ⚠️ Visible palette change — please eyeball
This shifts the brand palette: blue `#7EC7FF → #38BDF8`, plus a new gold accent `#F4C45C`. It restyles the live site. Preview locally with `pnpm dev`. Flag if you'd rather keep the exact old blue.

## Build
`astro check` clean (0 errors), 29 pages build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)